### PR TITLE
Fixed a concurrency issue in tests

### DIFF
--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicStorageTestHelper.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicStorageTestHelper.java
@@ -27,6 +27,10 @@ import com.evolvedbinary.j8fu.tuple.Tuple2;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Simple interface to make some {@link AtomicStorage} test methods
+ * accessible.
+ */
 public interface AtomicStorageTestHelper {
 
     static void clear() {
@@ -37,11 +41,11 @@ public interface AtomicStorageTestHelper {
         return AtomicStorage.INSTANCE.copy();
     }
 
-    static void set(final Map<String, Tuple2<AtomicType, Object>> atomicValues) {
-        AtomicStorage.INSTANCE.set(atomicValues);
-    }
-
     static void set(final String id, final Tuple2<AtomicType, Object> atomicValue) {
         AtomicStorage.INSTANCE.set(Collections.singletonMap(id, atomicValue));
+    }
+
+    static void put(final String id, final Tuple2<AtomicType, Object> atomicValue) {
+        AtomicStorage.INSTANCE.put(id, atomicValue);
     }
 }

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitIT.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitIT.java
@@ -388,7 +388,7 @@ public class AwaitIT {
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();  // restore interrupted flag
             }
-            AtomicStorageTestHelper.set(atomicIdFieldValue, new Tuple2<>(atomicType, atomicObj2));
+            AtomicStorageTestHelper.put(atomicIdFieldValue, new Tuple2<>(atomicType, atomicObj2));
         });
 
         final TransMeta transMeta = TransTestFactory.generateTestTransformation(new Variables(), awaitStepMeta, stepName);

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetIT.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetIT.java
@@ -639,7 +639,7 @@ public class CompareAndSetIT {
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();  // restore interrupted flag
             }
-            AtomicStorageTestHelper.set(atomicIdFieldValue, new Tuple2<>(atomicType, atomicObj2));
+            AtomicStorageTestHelper.put(atomicIdFieldValue, new Tuple2<>(atomicType, atomicObj2));
         });
 
         final TransMeta transMeta = TransTestFactory.generateTestTransformation(new Variables(), compareAndSetStepMeta, stepName);


### PR DESCRIPTION
Refactored so as not to mix non-thread-safe and thread-safe code. 
Previously there was a race in some of the multi-threaded tests that called `AtomicStorageTestHelper#set(...)` as that method performed a non-atomic update to the storage