### PR TITLE
Refactor for stronger type-checking

### DIFF
--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicBooleanValue.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicBooleanValue.java
@@ -22,28 +22,48 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Simple interface to make some {@link AtomicStorage} test methods
- * accessible.
+ * Simple wrapper around {@link AtomicBoolean} to
+ * allow us to have a common super-type with
+ * {@link AtomicBooleanValue}.
  */
-public interface AtomicStorageTestHelper {
+public class AtomicBooleanValue implements AtomicValue {
 
-    static void clear() {
-        AtomicStorage.INSTANCE.clear();
+    private final AtomicBoolean atomic;
+
+    /**
+     * Creates a new {@link AtomicBoolean} with the given initial value.
+     *
+     * @param initialValue the initial value
+     */
+    public AtomicBooleanValue(final boolean initialValue) {
+        this.atomic = new AtomicBoolean(initialValue);
     }
 
-    static Map<String, AtomicValue> copy() {
-        return AtomicStorage.INSTANCE.copy();
+    @Override
+    public AtomicType getType() {
+        return AtomicType.Boolean;
     }
 
-    static void set(final String id, final AtomicValue atomicValue) {
-        AtomicStorage.INSTANCE.set(Collections.singletonMap(id, atomicValue));
+    /**
+     * See {@link AtomicBoolean#get()}.
+     *
+     * @return the current value
+     */
+    public boolean get() {
+        return atomic.get();
     }
 
-    static void put(final String id, final AtomicValue atomicValue) {
-        AtomicStorage.INSTANCE.put(id, atomicValue);
+    /**
+     * See {@link AtomicBoolean#compareAndSet(boolean, boolean)}.
+     *
+     * @param expect the expected value
+     * @param update the new value
+     * @return {@code true} if successful.
+     */
+    public boolean compareAndSet(final boolean expect, final boolean update) {
+        return atomic.compareAndSet(expect, update);
     }
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicIntegerValue.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicIntegerValue.java
@@ -22,28 +22,48 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Simple interface to make some {@link AtomicStorage} test methods
- * accessible.
+ * Simple wrapper around {@link AtomicInteger} to
+ * allow us to have a common super-type with
+ * {@link AtomicBooleanValue}.
  */
-public interface AtomicStorageTestHelper {
+public class AtomicIntegerValue implements AtomicValue {
 
-    static void clear() {
-        AtomicStorage.INSTANCE.clear();
+    private final AtomicInteger atomic;
+
+    /**
+     * Creates a new {@link AtomicInteger} with the given initial value.
+     *
+     * @param initialValue the initial value
+     */
+    public AtomicIntegerValue(final int initialValue) {
+        this.atomic = new AtomicInteger(initialValue);
     }
 
-    static Map<String, AtomicValue> copy() {
-        return AtomicStorage.INSTANCE.copy();
+    @Override
+    public AtomicType getType() {
+        return AtomicType.Integer;
     }
 
-    static void set(final String id, final AtomicValue atomicValue) {
-        AtomicStorage.INSTANCE.set(Collections.singletonMap(id, atomicValue));
+    /**
+     * See {@link AtomicInteger#get()}.
+     *
+     * @return the current value
+     */
+    public int get() {
+        return atomic.get();
     }
 
-    static void put(final String id, final AtomicValue atomicValue) {
-        AtomicStorage.INSTANCE.put(id, atomicValue);
+    /**
+     * See {@link AtomicInteger#compareAndSet(int, int)}.
+     *
+     * @param expect the expected value
+     * @param update the new value
+     * @return {@code true} if successful.
+     */
+    public boolean compareAndSet(final int expect, final int update) {
+       return atomic.compareAndSet(expect, update);
     }
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicValue.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicValue.java
@@ -22,28 +22,19 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics;
 
-import java.util.Collections;
-import java.util.Map;
-
 /**
- * Simple interface to make some {@link AtomicStorage} test methods
- * accessible.
+ * Simple Type Class to provide a more
+ * meaningful super-type than just Object when
+ * abstracting operations of both
+ * {@link java.util.concurrent.atomic.AtomicBoolean} and
+ * {@link java.util.concurrent.atomic.AtomicInteger}.
  */
-public interface AtomicStorageTestHelper {
+public interface AtomicValue {
 
-    static void clear() {
-        AtomicStorage.INSTANCE.clear();
-    }
-
-    static Map<String, AtomicValue> copy() {
-        return AtomicStorage.INSTANCE.copy();
-    }
-
-    static void set(final String id, final AtomicValue atomicValue) {
-        AtomicStorage.INSTANCE.set(Collections.singletonMap(id, atomicValue));
-    }
-
-    static void put(final String id, final AtomicValue atomicValue) {
-        AtomicStorage.INSTANCE.put(id, atomicValue);
-    }
+    /**
+     * Get the type tag of the atomic value.
+     *
+     * @return the type tag of the atomic value;
+     */
+    AtomicType getType();
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -30,12 +30,7 @@ import org.pentaho.di.i18n.BaseMessages;
 import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.*;
-import uk.gov.nationalarchives.pdi.step.atomics.ActionIfNoAtomic;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
-import uk.gov.nationalarchives.pdi.step.atomics.ErrorCodes;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import uk.gov.nationalarchives.pdi.step.atomics.*;
 
 import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNotEmpty;
 
@@ -87,15 +82,15 @@ public class AwaitStep extends BaseStep implements StepInterface {
 
 
         long waitedForAtomic = 0;
-        Object atomicObj = null;
+        AtomicValue atomicValue = null;
         while (true) {
             if (ActionIfNoAtomic.Initialise == actionIfNoAtomic) {
-                atomicObj = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
+                atomicValue = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
             } else {
-                atomicObj = data.getAtomic(atomicId, atomicType);
+                atomicValue = data.getAtomic(atomicId, atomicType);
             }
 
-            if (atomicObj != null) {
+            if (atomicValue != null) {
                 break;  // exit while loop
             }
 
@@ -163,16 +158,16 @@ public class AwaitStep extends BaseStep implements StepInterface {
         while (true) {
 
             // refresh the atomic object
-            atomicObj = data.getAtomic(atomicId, atomicType);
+            atomicValue = data.getAtomic(atomicId, atomicType);
 
             if (AtomicType.Boolean == atomicType) {
-                final AtomicBoolean atomicBoolean = (AtomicBoolean) atomicObj;
+                final AtomicBooleanValue atomicBoolean = (AtomicBooleanValue) atomicValue;
                 final boolean awaitValueBoolean = Boolean.valueOf(meta.getAtomicValue());
                 atomicIsEqual = awaitValueBoolean == atomicBoolean.get();
 
             } else if (AtomicType.Integer == atomicType) {
                 final int awaitValueInt = Integer.valueOf(meta.getAtomicValue());
-                final AtomicInteger atomicInteger = (AtomicInteger) atomicObj;
+                final AtomicIntegerValue atomicInteger = (AtomicIntegerValue) atomicValue;
                 atomicIsEqual = awaitValueInt == atomicInteger.get();
 
             } else {

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepData.java
@@ -28,6 +28,7 @@ import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicStorage;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
+import uk.gov.nationalarchives.pdi.step.atomics.AtomicValue;
 
 import javax.annotation.Nullable;
 
@@ -45,11 +46,12 @@ public class AwaitStepData extends BaseStepData implements StepDataInterface {
         super();
     }
 
-    public @Nullable Object getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
+    public @Nullable
+    AtomicValue getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
         return AtomicStorage.INSTANCE.getAtomic(id, atomicType);
     }
 
-    public Object getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
+    public AtomicValue getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
         return AtomicStorage.INSTANCE.getOrCreateAtomic(id, atomicType, initialValue);
     }
 

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
@@ -31,15 +31,10 @@ import org.pentaho.di.trans.Trans;
 import org.pentaho.di.trans.TransMeta;
 import org.pentaho.di.trans.step.*;
 import org.pentaho.di.trans.step.errorhandling.StreamInterface;
-import uk.gov.nationalarchives.pdi.step.atomics.ActionIfNoAtomic;
-import uk.gov.nationalarchives.pdi.step.atomics.ActionIfUnableToSet;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
-import uk.gov.nationalarchives.pdi.step.atomics.ErrorCodes;
+import uk.gov.nationalarchives.pdi.step.atomics.*;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNotEmpty;
 import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNullOrEmpty;
@@ -89,15 +84,15 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
         final long waitAtomicTimeout = meta.getWaitAtomicTimeout();
 
         long waitedForAtomic = 0;
-        Object atomicObj = null;
+        AtomicValue atomicValue = null;
         while (true) {
             if (ActionIfNoAtomic.Initialise == actionIfNoAtomic) {
-                atomicObj = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
+                atomicValue = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
             } else {
-                atomicObj = data.getAtomic(atomicId, atomicType);
+                atomicValue = data.getAtomic(atomicId, atomicType);
             }
 
-            if (atomicObj != null) {
+            if (atomicValue != null) {
                 break;  // exit while loop
             }
 
@@ -170,7 +165,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             while (true) {
 
                 // refresh the atomic object
-                atomicObj = data.getAtomic(atomicId, atomicType);
+                atomicValue = data.getAtomic(atomicId, atomicType);
 
                 set = false;
 
@@ -178,13 +173,13 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                 for (final CompareAndSetTarget compareAndSetValue : compareAndSetValues) {
 
                     if (AtomicType.Boolean == atomicType) {
-                        final AtomicBoolean atomicBoolean = (AtomicBoolean) atomicObj;
+                        final AtomicBooleanValue atomicBoolean = (AtomicBooleanValue) atomicValue;
                         final boolean compareValue = Boolean.valueOf(compareAndSetValue.getCompareValue());
                         final boolean setValue = Boolean.valueOf(compareAndSetValue.getSetValue());
                         set = atomicBoolean.compareAndSet(compareValue, setValue);
 
                     } else if (AtomicType.Integer == atomicType) {
-                        final AtomicInteger atomicInteger = (AtomicInteger) atomicObj;
+                        final AtomicIntegerValue atomicInteger = (AtomicIntegerValue) atomicValue;
                         final int compareValue = Integer.valueOf(compareAndSetValue.getCompareValue());
                         final int setValue = Integer.valueOf(compareAndSetValue.getSetValue());
                         set = atomicInteger.compareAndSet(compareValue, setValue);

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepData.java
@@ -28,6 +28,7 @@ import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicStorage;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
+import uk.gov.nationalarchives.pdi.step.atomics.AtomicValue;
 
 import javax.annotation.Nullable;
 
@@ -47,11 +48,12 @@ public class CompareAndSetStepData extends BaseStepData implements StepDataInter
         super();
     }
 
-    public @Nullable Object getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
+    public @Nullable
+    AtomicValue getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
         return AtomicStorage.INSTANCE.getAtomic(id, atomicType);
     }
 
-    public Object getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
+    public AtomicValue getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
         return AtomicStorage.INSTANCE.getOrCreateAtomic(id, atomicType, initialValue);
     }
 

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicStorageTest.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/AtomicStorageTest.java
@@ -22,12 +22,8 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics;
 
-import static com.evolvedbinary.j8fu.tuple.Tuple.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,70 +42,70 @@ public class AtomicStorageTest {
     @Test
     public void getAtomicInteger() {
         // 1st prepare the storage
-        final AtomicInteger atomicInt1 = new AtomicInteger(1);
-        AtomicStorageTestHelper.set("atomicInt1", Tuple(AtomicType.Integer, atomicInt1));
+        final AtomicValue atomicInt1 = new AtomicIntegerValue(1);
+        AtomicStorageTestHelper.set("atomicInt1", atomicInt1);
 
         // 2nd retrieve
-        final Object atomicInt11 = AtomicStorage.INSTANCE.getAtomic("atomicInt1", AtomicType.Integer);
+        final AtomicValue atomicInt11 = AtomicStorage.INSTANCE.getAtomic("atomicInt1", AtomicType.Integer);
         assertNotNull(atomicInt11);
-        assertTrue(atomicInt11 instanceof AtomicInteger);
+        assertTrue(atomicInt11 instanceof AtomicIntegerValue);
         assertTrue(atomicInt11 == atomicInt1);
-        assertEquals(1, ((AtomicInteger) atomicInt11).get());
+        assertEquals(1, ((AtomicIntegerValue) atomicInt11).get());
     }
 
     @Test
     public void getAtomicBoolean() {
         // 1st prepare the storage
-        final AtomicBoolean atomicBool1 = new AtomicBoolean(true);
-        AtomicStorageTestHelper.set("atomicBool1", Tuple(AtomicType.Boolean, atomicBool1));
+        final AtomicValue atomicBool1 = new AtomicBooleanValue(true);
+        AtomicStorageTestHelper.set("atomicBool1", atomicBool1);
 
         // 2nd retrieve
-        final Object atomicBool11 = AtomicStorage.INSTANCE.getAtomic("atomicBool1", AtomicType.Boolean);
+        final AtomicValue atomicBool11 = AtomicStorage.INSTANCE.getAtomic("atomicBool1", AtomicType.Boolean);
         assertNotNull(atomicBool11);
-        assertTrue(atomicBool11 instanceof AtomicBoolean);
+        assertTrue(atomicBool11 instanceof AtomicBooleanValue);
         assertTrue(atomicBool11 == atomicBool1);
-        assertTrue(((AtomicBoolean) atomicBool11).get());
+        assertTrue(((AtomicBooleanValue) atomicBool11).get());
     }
 
     @Test
     public void createThenGetAtomicInteger() {
         // 1st create
-        final Object atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
+        final AtomicValue atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
         assertNotNull(atomicInt1);
-        assertTrue(atomicInt1 instanceof AtomicInteger);
-        assertEquals(1, ((AtomicInteger) atomicInt1).get());
+        assertTrue(atomicInt1 instanceof AtomicIntegerValue);
+        assertEquals(1, ((AtomicIntegerValue) atomicInt1).get());
 
         // 2nd retrieve
-        final Object atomicInt11 = AtomicStorage.INSTANCE.getAtomic("atomicInt1", AtomicType.Integer);
+        final AtomicValue atomicInt11 = AtomicStorage.INSTANCE.getAtomic("atomicInt1", AtomicType.Integer);
         assertNotNull(atomicInt11);
-        assertTrue(atomicInt11 instanceof AtomicInteger);
+        assertTrue(atomicInt11 instanceof AtomicIntegerValue);
         assertTrue(atomicInt11 == atomicInt1);
-        assertEquals(1, ((AtomicInteger) atomicInt11).get());
+        assertEquals(1, ((AtomicIntegerValue) atomicInt11).get());
     }
 
     @Test
     public void createThenGetAtomicBoolean() {
         // 1st create
-        final Object atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
+        final AtomicValue atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
         assertNotNull(atomicBool1);
-        assertTrue(atomicBool1 instanceof AtomicBoolean);
-        assertTrue(((AtomicBoolean) atomicBool1).get());
+        assertTrue(atomicBool1 instanceof AtomicBooleanValue);
+        assertTrue(((AtomicBooleanValue) atomicBool1).get());
 
         // 2nd retrieve
-        final Object atomicBool11 = AtomicStorage.INSTANCE.getAtomic("atomicBool1", AtomicType.Boolean);
+        final AtomicValue atomicBool11 = AtomicStorage.INSTANCE.getAtomic("atomicBool1", AtomicType.Boolean);
         assertNotNull(atomicBool11);
-        assertTrue(atomicBool11 instanceof AtomicBoolean);
+        assertTrue(atomicBool11 instanceof AtomicBooleanValue);
         assertTrue(atomicBool11 == atomicBool1);
-        assertTrue(((AtomicBoolean) atomicBool11).get());
+        assertTrue(((AtomicBooleanValue) atomicBool11).get());
     }
 
     @Test
     public void createThenGetAtomicIntegerInvalidType() {
         // 1st create
-        final Object atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
+        final AtomicValue atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
         assertNotNull(atomicInt1);
-        assertTrue(atomicInt1 instanceof AtomicInteger);
-        assertEquals(1, ((AtomicInteger) atomicInt1).get());
+        assertTrue(atomicInt1 instanceof AtomicIntegerValue);
+        assertEquals(1, ((AtomicIntegerValue) atomicInt1).get());
 
         // 2nd retrieve
         assertThrows(IllegalArgumentException.class,
@@ -120,10 +116,10 @@ public class AtomicStorageTest {
     @Test
     public void createThenGetAtomicBooleanInvalidType() {
         // 1st create
-        final Object atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
+        final AtomicValue atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
         assertNotNull(atomicBool1);
-        assertTrue(atomicBool1 instanceof AtomicBoolean);
-        assertTrue(((AtomicBoolean) atomicBool1).get());
+        assertTrue(atomicBool1 instanceof AtomicBooleanValue);
+        assertTrue(((AtomicBooleanValue) atomicBool1).get());
 
         // 2nd retrieve
         assertThrows(IllegalArgumentException.class,
@@ -134,42 +130,42 @@ public class AtomicStorageTest {
     @Test
     public void getOrCreateAtomicInteger() {
         // 1st call - create
-        final Object atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
+        final AtomicValue atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
         assertNotNull(atomicInt1);
-        assertTrue(atomicInt1 instanceof AtomicInteger);
-        assertEquals(1, ((AtomicInteger) atomicInt1).get());
+        assertTrue(atomicInt1 instanceof AtomicIntegerValue);
+        assertEquals(1, ((AtomicIntegerValue) atomicInt1).get());
 
         // 2nd call - get
-        final Object atomicInt11 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "2");
+        final AtomicValue atomicInt11 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "2");
         assertNotNull(atomicInt11);
-        assertTrue(atomicInt11 instanceof AtomicInteger);
+        assertTrue(atomicInt11 instanceof AtomicIntegerValue);
         assertTrue(atomicInt11 == atomicInt1);
-        assertEquals(1, ((AtomicInteger) atomicInt11).get());
+        assertEquals(1, ((AtomicIntegerValue) atomicInt11).get());
     }
 
     @Test
     public void getOrCreateAtomicBoolean() {
         // 1st call - create
-        final Object atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
+        final AtomicValue atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
         assertNotNull(atomicBool1);
-        assertTrue(atomicBool1 instanceof AtomicBoolean);
-        assertTrue(((AtomicBoolean) atomicBool1).get());
+        assertTrue(atomicBool1 instanceof AtomicBooleanValue);
+        assertTrue(((AtomicBooleanValue) atomicBool1).get());
 
         // 2nd call - get
-        final Object atomicBool11 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "false");
+        final AtomicValue atomicBool11 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "false");
         assertNotNull(atomicBool11);
-        assertTrue(atomicBool11 instanceof AtomicBoolean);
+        assertTrue(atomicBool11 instanceof AtomicBooleanValue);
         assertTrue(atomicBool11 == atomicBool1);
-        assertTrue(((AtomicBoolean) atomicBool11).get());
+        assertTrue(((AtomicBooleanValue) atomicBool11).get());
     }
 
     @Test
     public void getOrCreateAtomicIntegerInvalidType() {
         // 1st call - create
-        final Object atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
+        final AtomicValue atomicInt1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicInt1", AtomicType.Integer, "1");
         assertNotNull(atomicInt1);
-        assertTrue(atomicInt1 instanceof AtomicInteger);
-        assertEquals(1, ((AtomicInteger) atomicInt1).get());
+        assertTrue(atomicInt1 instanceof AtomicIntegerValue);
+        assertEquals(1, ((AtomicIntegerValue) atomicInt1).get());
 
         // 2nd call - get
         assertThrows(IllegalArgumentException.class,
@@ -180,10 +176,10 @@ public class AtomicStorageTest {
     @Test
     public void getOrCreateAtomicBooleanInvalidType() {
         // 1st call - create
-        final Object atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
+        final AtomicValue atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
         assertNotNull(atomicBool1);
-        assertTrue(atomicBool1 instanceof AtomicBoolean);
-        assertTrue(((AtomicBoolean) atomicBool1).get());
+        assertTrue(atomicBool1 instanceof AtomicBooleanValue);
+        assertTrue(((AtomicBooleanValue) atomicBool1).get());
 
         // 2nd call - get
         assertThrows(IllegalArgumentException.class,
@@ -199,10 +195,10 @@ public class AtomicStorageTest {
     @Test
     public void remove() {
         // 1st call - create
-        final Object atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
+        final AtomicValue atomicBool1 = AtomicStorage.INSTANCE.getOrCreateAtomic("atomicBool1", AtomicType.Boolean, "true");
         assertNotNull(atomicBool1);
-        assertTrue(atomicBool1 instanceof AtomicBoolean);
-        assertTrue(((AtomicBoolean) atomicBool1).get());
+        assertTrue(atomicBool1 instanceof AtomicBooleanValue);
+        assertTrue(((AtomicBooleanValue) atomicBool1).get());
 
         // 2nd call - remove
         assertTrue(AtomicStorage.INSTANCE.removeAtomic("atomicBool1"));

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetIT.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetIT.java
@@ -22,7 +22,6 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics.compareandset;
 
-import com.evolvedbinary.j8fu.tuple.Tuple2;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,11 +43,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import static com.evolvedbinary.j8fu.tuple.Tuple.Tuple;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class CompareAndSetIT {
@@ -93,17 +89,17 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertEquals(1, stored.size());
-        final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
+        final AtomicValue atomicValue = stored.get(atomicIdFieldValue);
         assertNotNull(atomicValue);
-        assertEquals(atomicType, atomicValue._1);
+        assertEquals(atomicType, atomicValue.getType());
         if (atomicType == AtomicType.Integer) {
-            assertTrue(atomicValue._2 instanceof AtomicInteger);
-            assertEquals(Integer.valueOf(initialiseValue), ((AtomicInteger) atomicValue._2).get());
+            assertTrue(atomicValue instanceof AtomicIntegerValue);
+            assertEquals(Integer.valueOf(initialiseValue), ((AtomicIntegerValue) atomicValue).get());
         } else {
-            assertTrue(atomicValue._2 instanceof AtomicBoolean);
-            assertEquals(Boolean.valueOf(initialiseValue), ((AtomicBoolean) atomicValue._2).get());
+            assertTrue(atomicValue instanceof AtomicBooleanValue);
+            assertEquals(Boolean.valueOf(initialiseValue), ((AtomicBooleanValue) atomicValue).get());
         }
     }
 
@@ -124,9 +120,9 @@ public class CompareAndSetIT {
 
         // prepare the storage
         if (atomicType == AtomicType.Integer) {
-            AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, new AtomicInteger(Integer.parseInt(existingAtomicValue))));
+            AtomicStorageTestHelper.set(atomicIdFieldValue, new AtomicIntegerValue(Integer.parseInt(existingAtomicValue)));
         } else {
-            AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, new AtomicBoolean(Boolean.parseBoolean(existingAtomicValue))));
+            AtomicStorageTestHelper.set(atomicIdFieldValue, new AtomicBooleanValue(Boolean.parseBoolean(existingAtomicValue)));
         }
 
         final CompareAndSetStepMeta compareAndSetStepMeta = new CompareAndSetStepMeta();
@@ -144,17 +140,17 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertEquals(1, stored.size());
-        final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
+        final AtomicValue atomicValue = stored.get(atomicIdFieldValue);
         assertNotNull(atomicValue);
-        assertEquals(atomicType, atomicValue._1);
+        assertEquals(atomicType, atomicValue.getType());
         if (atomicType == AtomicType.Integer) {
-            assertTrue(atomicValue._2 instanceof AtomicInteger);
-            assertEquals(Integer.valueOf(existingAtomicValue), ((AtomicInteger) atomicValue._2).get());
+            assertTrue(atomicValue instanceof AtomicIntegerValue);
+            assertEquals(Integer.valueOf(existingAtomicValue), ((AtomicIntegerValue) atomicValue).get());
         } else {
-            assertTrue(atomicValue._2 instanceof AtomicBoolean);
-            assertEquals(Boolean.valueOf(existingAtomicValue), ((AtomicBoolean) atomicValue._2).get());
+            assertTrue(atomicValue instanceof AtomicBooleanValue);
+            assertEquals(Boolean.valueOf(existingAtomicValue), ((AtomicBooleanValue) atomicValue).get());
         }
     }
 
@@ -219,7 +215,7 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertTrue(stored.isEmpty());
     }
 
@@ -245,11 +241,11 @@ public class CompareAndSetIT {
         compareAndSetStepMeta.setWaitAtomicTimeout(5000);  // a suitably long time to enable us to set it
         compareAndSetStepMeta.setWaitAtomicCheckPeriod(50);
 
-        final Object atomicObj;
+        final AtomicValue atomicValue;
         if (atomicType == AtomicType.Integer) {
-            atomicObj = new AtomicInteger(Integer.parseInt(waitForValue));
+            atomicValue = new AtomicIntegerValue(Integer.parseInt(waitForValue));
         } else {
-            atomicObj = new AtomicBoolean(Boolean.parseBoolean(waitForValue));
+            atomicValue = new AtomicBooleanValue(Boolean.parseBoolean(waitForValue));
         }
 
         final Thread setAtomicThread = new Thread(() -> {
@@ -258,7 +254,7 @@ public class CompareAndSetIT {
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();  // restore interrupted flag
             }
-            AtomicStorageTestHelper.set(atomicIdFieldValue, new Tuple2<>(atomicType, atomicObj));
+            AtomicStorageTestHelper.set(atomicIdFieldValue, atomicValue);
         });
 
         final TransMeta transMeta = TransTestFactory.generateTestTransformation(new Variables(), compareAndSetStepMeta, stepName);
@@ -273,17 +269,17 @@ public class CompareAndSetIT {
                     generateInputData(atomicIdFieldName, atomicIdFieldValue));
             assertEquals(1, result.size());
 
-            final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+            final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
             assertEquals(1, stored.size());
-            final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
-            assertNotNull(atomicValue);
-            assertEquals(atomicType, atomicValue._1);
+            final AtomicValue atomicValueResult = stored.get(atomicIdFieldValue);
+            assertNotNull(atomicValueResult);
+            assertEquals(atomicType, atomicValue.getType());
             if (atomicType == AtomicType.Integer) {
-                assertTrue(atomicValue._2 instanceof AtomicInteger);
-                assertEquals(Integer.valueOf(waitForValue), ((AtomicInteger) atomicValue._2).get());
+                assertTrue(atomicValueResult instanceof AtomicIntegerValue);
+                assertEquals(Integer.valueOf(waitForValue), ((AtomicIntegerValue) atomicValueResult).get());
             } else {
-                assertTrue(atomicValue._2 instanceof AtomicBoolean);
-                assertEquals(Boolean.valueOf(waitForValue), ((AtomicBoolean) atomicValue._2).get());
+                assertTrue(atomicValueResult instanceof AtomicBooleanValue);
+                assertEquals(Boolean.valueOf(waitForValue), ((AtomicBooleanValue) atomicValueResult).get());
             }
 
         } finally {
@@ -381,17 +377,17 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertEquals(1, stored.size());
-        final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
+        final AtomicValue atomicValue = stored.get(atomicIdFieldValue);
         assertNotNull(atomicValue);
-        assertEquals(atomicType, atomicValue._1);
+        assertEquals(atomicType, atomicValue.getType());
         if (atomicType == AtomicType.Integer) {
-            assertTrue(atomicValue._2 instanceof AtomicInteger);
-            assertEquals(Integer.valueOf(expectedValue), ((AtomicInteger) atomicValue._2).get());
+            assertTrue(atomicValue instanceof AtomicIntegerValue);
+            assertEquals(Integer.valueOf(expectedValue), ((AtomicIntegerValue) atomicValue).get());
         } else {
-            assertTrue(atomicValue._2 instanceof AtomicBoolean);
-            assertEquals(Boolean.valueOf(expectedValue), ((AtomicBoolean) atomicValue._2).get());
+            assertTrue(atomicValue instanceof AtomicBooleanValue);
+            assertEquals(Boolean.valueOf(expectedValue), ((AtomicBooleanValue) atomicValue).get());
         }
     }
 
@@ -428,13 +424,13 @@ public class CompareAndSetIT {
         final String atomicIdFieldValue = "atomicId1";
 
         // prepare the storage
-        final Object atomicObj;
+        final AtomicValue atomicValue;
         if (atomicType == AtomicType.Integer) {
-            atomicObj = new AtomicInteger(Integer.parseInt(existingAtomicValue));
+            atomicValue = new AtomicIntegerValue(Integer.parseInt(existingAtomicValue));
         } else {
-            atomicObj = new AtomicBoolean(Boolean.parseBoolean(existingAtomicValue));
+            atomicValue = new AtomicBooleanValue(Boolean.parseBoolean(existingAtomicValue));
         }
-        AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, atomicObj));
+        AtomicStorageTestHelper.set(atomicIdFieldValue, atomicValue);
 
         final CompareAndSetStepMeta compareAndSetStepMeta = new CompareAndSetStepMeta();
         compareAndSetStepMeta.setAtomicIdFieldName(atomicIdFieldName);
@@ -452,17 +448,17 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertEquals(1, stored.size());
-        final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
-        assertNotNull(atomicValue);
-        assertEquals(atomicType, atomicValue._1);
+        final AtomicValue atomicValueResult = stored.get(atomicIdFieldValue);
+        assertNotNull(atomicValueResult);
+        assertEquals(atomicType, atomicValueResult.getType());
         if (atomicType == AtomicType.Integer) {
-            assertTrue(atomicValue._2 instanceof AtomicInteger);
-            assertEquals(Integer.valueOf(expectedValue), ((AtomicInteger) atomicValue._2).get());
+            assertTrue(atomicValueResult instanceof AtomicIntegerValue);
+            assertEquals(Integer.valueOf(expectedValue), ((AtomicIntegerValue) atomicValueResult).get());
         } else {
-            assertTrue(atomicValue._2 instanceof AtomicBoolean);
-            assertEquals(Boolean.valueOf(expectedValue), ((AtomicBoolean) atomicValue._2).get());
+            assertTrue(atomicValueResult instanceof AtomicBooleanValue);
+            assertEquals(Boolean.valueOf(expectedValue), ((AtomicBooleanValue) atomicValueResult).get());
         }
     }
 
@@ -486,13 +482,13 @@ public class CompareAndSetIT {
         final String atomicIdFieldValue = "atomicId1";
 
         // prepare the storage
-        final Object atomicObj;
+        final AtomicValue atomicValue;
         if (atomicType ==  AtomicType.Integer) {
-            atomicObj = new AtomicInteger(Integer.parseInt(existingAtomicValue));
+            atomicValue = new AtomicIntegerValue(Integer.parseInt(existingAtomicValue));
         } else {
-            atomicObj = new AtomicBoolean(Boolean.parseBoolean(existingAtomicValue));
+            atomicValue = new AtomicBooleanValue(Boolean.parseBoolean(existingAtomicValue));
         }
-        AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, atomicObj));
+        AtomicStorageTestHelper.set(atomicIdFieldValue, atomicValue);
 
         final CompareAndSetStepMeta compareAndSetStepMeta = new CompareAndSetStepMeta();
         compareAndSetStepMeta.setAtomicIdFieldName(atomicIdFieldName);
@@ -512,17 +508,17 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertEquals(1, stored.size());
-        final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
-        assertNotNull(atomicValue);
-        assertEquals(atomicType, atomicValue._1);
+        final AtomicValue atomicValueResult = stored.get(atomicIdFieldValue);
+        assertNotNull(atomicValueResult);
+        assertEquals(atomicType, atomicValueResult.getType());
         if (atomicType == AtomicType.Integer) {
-            assertTrue(atomicValue._2 instanceof AtomicInteger);
-            assertEquals(Integer.valueOf(existingAtomicValue), ((AtomicInteger) atomicValue._2).get());
+            assertTrue(atomicValueResult instanceof AtomicIntegerValue);
+            assertEquals(Integer.valueOf(existingAtomicValue), ((AtomicIntegerValue) atomicValueResult).get());
         } else {
-            assertTrue(atomicValue._2 instanceof AtomicBoolean);
-            assertEquals(Boolean.valueOf(existingAtomicValue), ((AtomicBoolean) atomicValue._2).get());
+            assertTrue(atomicValueResult instanceof AtomicBooleanValue);
+            assertEquals(Boolean.valueOf(existingAtomicValue), ((AtomicBooleanValue) atomicValueResult).get());
         }
     }
 
@@ -546,13 +542,13 @@ public class CompareAndSetIT {
         final String atomicIdFieldValue = "atomicId1";
 
         // prepare the storage
-        final Object atomicObj;
+        final AtomicValue atomicValue;
         if (atomicType ==  AtomicType.Integer) {
-            atomicObj = new AtomicInteger(Integer.parseInt(existingAtomicValue));
+            atomicValue = new AtomicIntegerValue(Integer.parseInt(existingAtomicValue));
         } else {
-            atomicObj = new AtomicBoolean(Boolean.parseBoolean(existingAtomicValue));
+            atomicValue = new AtomicBooleanValue(Boolean.parseBoolean(existingAtomicValue));
         }
-        AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, atomicObj));
+        AtomicStorageTestHelper.set(atomicIdFieldValue, atomicValue);
 
         final CompareAndSetStepMeta compareAndSetStepMeta = new CompareAndSetStepMeta();
         compareAndSetStepMeta.setAtomicIdFieldName(atomicIdFieldName);
@@ -609,13 +605,13 @@ public class CompareAndSetIT {
         final String atomicIdFieldValue = "atomicId1";
 
         // prepare the storage
-        final Object atomicObj;
+        final AtomicValue atomicValue;
         if (atomicType ==  AtomicType.Integer) {
-            atomicObj = new AtomicInteger(Integer.parseInt(existingAtomicValue));
+            atomicValue = new AtomicIntegerValue(Integer.parseInt(existingAtomicValue));
         } else {
-            atomicObj = new AtomicBoolean(Boolean.parseBoolean(existingAtomicValue));
+            atomicValue = new AtomicBooleanValue(Boolean.parseBoolean(existingAtomicValue));
         }
-        AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, atomicObj));
+        AtomicStorageTestHelper.set(atomicIdFieldValue, atomicValue);
 
         final CompareAndSetStepMeta compareAndSetStepMeta = new CompareAndSetStepMeta();
         compareAndSetStepMeta.setAtomicIdFieldName(atomicIdFieldName);
@@ -627,11 +623,11 @@ public class CompareAndSetIT {
 
         compareAndSetStepMeta.setCompareAndSetValues(compareAndSetValues);
 
-        final Object atomicObj2;
+        final AtomicValue atomicValue2;
         if (atomicType == AtomicType.Integer) {
-            atomicObj2 = new AtomicInteger(Integer.parseInt(updatedAtomicValue));
+            atomicValue2 = new AtomicIntegerValue(Integer.parseInt(updatedAtomicValue));
         } else {
-            atomicObj2 = new AtomicBoolean(Boolean.parseBoolean(updatedAtomicValue));
+            atomicValue2 = new AtomicBooleanValue(Boolean.parseBoolean(updatedAtomicValue));
         }
         final Thread setAtomicThread = new Thread(() -> {
             try {
@@ -639,7 +635,7 @@ public class CompareAndSetIT {
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();  // restore interrupted flag
             }
-            AtomicStorageTestHelper.put(atomicIdFieldValue, new Tuple2<>(atomicType, atomicObj2));
+            AtomicStorageTestHelper.put(atomicIdFieldValue, atomicValue2);
         });
 
         final TransMeta transMeta = TransTestFactory.generateTestTransformation(new Variables(), compareAndSetStepMeta, stepName);
@@ -654,17 +650,17 @@ public class CompareAndSetIT {
                     generateInputData(atomicIdFieldName, atomicIdFieldValue));
             assertEquals(1, result.size());
 
-            final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+            final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
             assertEquals(1, stored.size());
-            final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
-            assertNotNull(atomicValue);
-            assertEquals(atomicType, atomicValue._1);
+            final AtomicValue atomicValueResult = stored.get(atomicIdFieldValue);
+            assertNotNull(atomicValueResult);
+            assertEquals(atomicType, atomicValueResult.getType());
             if (atomicType == AtomicType.Integer) {
-                assertTrue(atomicValue._2 instanceof AtomicInteger);
-                assertEquals(Integer.valueOf(expectedValue), ((AtomicInteger) atomicValue._2).get());
+                assertTrue(atomicValueResult instanceof AtomicIntegerValue);
+                assertEquals(Integer.valueOf(expectedValue), ((AtomicIntegerValue) atomicValueResult).get());
             } else {
-                assertTrue(atomicValue._2 instanceof AtomicBoolean);
-                assertEquals(Boolean.valueOf(expectedValue), ((AtomicBoolean) atomicValue._2).get());
+                assertTrue(atomicValueResult instanceof AtomicBooleanValue);
+                assertEquals(Boolean.valueOf(expectedValue), ((AtomicBooleanValue) atomicValueResult).get());
             }
         } finally {
             setAtomicThread.join();
@@ -691,13 +687,13 @@ public class CompareAndSetIT {
         final String atomicIdFieldValue = "atomicId1";
 
         // prepare the storage
-        final Object atomicObj;
+        final AtomicValue atomicValue;
         if (atomicType ==  AtomicType.Integer) {
-            atomicObj = new AtomicInteger(Integer.parseInt(existingAtomicValue));
+            atomicValue = new AtomicIntegerValue(Integer.parseInt(existingAtomicValue));
         } else {
-            atomicObj = new AtomicBoolean(Boolean.parseBoolean(existingAtomicValue));
+            atomicValue = new AtomicBooleanValue(Boolean.parseBoolean(existingAtomicValue));
         }
-        AtomicStorageTestHelper.set(atomicIdFieldValue, Tuple(atomicType, atomicObj));
+        AtomicStorageTestHelper.set(atomicIdFieldValue, atomicValue);
 
         final CompareAndSetStepMeta compareAndSetStepMeta = new CompareAndSetStepMeta();
         compareAndSetStepMeta.setAtomicIdFieldName(atomicIdFieldName);
@@ -719,17 +715,17 @@ public class CompareAndSetIT {
                 generateInputData(atomicIdFieldName, atomicIdFieldValue));
         assertEquals(1, result.size());
 
-        final Map<String, Tuple2<AtomicType, Object>> stored = AtomicStorageTestHelper.copy();
+        final Map<String, AtomicValue> stored = AtomicStorageTestHelper.copy();
         assertEquals(1, stored.size());
-        final Tuple2<AtomicType, Object> atomicValue = stored.get(atomicIdFieldValue);
-        assertNotNull(atomicValue);
-        assertEquals(atomicType, atomicValue._1);
+        final AtomicValue atomicValueResult = stored.get(atomicIdFieldValue);
+        assertNotNull(atomicValueResult);
+        assertEquals(atomicType, atomicValueResult.getType());
         if (atomicType == AtomicType.Integer) {
-            assertTrue(atomicValue._2 instanceof AtomicInteger);
-            assertEquals(Integer.valueOf(existingAtomicValue), ((AtomicInteger) atomicValue._2).get());
+            assertTrue(atomicValueResult instanceof AtomicIntegerValue);
+            assertEquals(Integer.valueOf(existingAtomicValue), ((AtomicIntegerValue) atomicValueResult).get());
         } else {
-            assertTrue(atomicValue._2 instanceof AtomicBoolean);
-            assertEquals(Boolean.valueOf(existingAtomicValue), ((AtomicBoolean) atomicValue._2).get());
+            assertTrue(atomicValueResult instanceof AtomicBooleanValue);
+            assertEquals(Boolean.valueOf(existingAtomicValue), ((AtomicBooleanValue) atomicValueResult).get());
         }
     }
 


### PR DESCRIPTION
Previously `AtomicStorage` could store either a `java.util.concurrent.atomic.AtomicBoolean` or `java.util.concurrent.atomic.AtomicInteger`, however as there is no common super-type between those two types, `AtomicStorage` methods had to work with `Object` type.

This refactoring simply wraps `AtomicBoolean` and `AtomicInteger` inside our own classes `AtomicBooleanValue` and `AtomicIntegerValue`; which have a new common super-type `AtomicValue`.

This allows our `AtomicStorage` to work with the stricter `AtomicValue` type instead of just `Object`. Thus improving type-checking at compilation time.