### PR TITLE
AwaitStep can now wait on one of several values (including null)

### DIFF
--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AbstractAtomicStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AbstractAtomicStep.java
@@ -1,0 +1,251 @@
+/**
+ * The MIT License
+ * Copyright © 2021 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package uk.gov.nationalarchives.pdi.step.atomics;
+
+import com.evolvedbinary.j8fu.Either;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.exception.KettleStepException;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.BaseStep;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepInterface;
+import org.pentaho.di.trans.step.StepMeta;
+
+import static com.evolvedbinary.j8fu.Either.Left;
+import static com.evolvedbinary.j8fu.Either.Right;
+import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNotEmpty;
+
+public abstract class AbstractAtomicStep extends BaseStep implements StepInterface {
+
+    protected enum GetAtomicRouteTarget {
+        CONTINUE,
+        ERROR,
+        TIMEOUT,
+        THREAD_INTERRUPTED
+    }
+
+    public AbstractAtomicStep(final StepMeta stepMeta, final StepDataInterface stepDataInterface, final int copyNr,
+            final TransMeta transMeta, final Trans trans) {
+        super(stepMeta, stepDataInterface, copyNr, transMeta, trans);
+    }
+
+    /**
+     * Get the Atomic ID from the input row.
+     *
+     * @param data the Step Data instance
+     * @param row the row
+     *
+     * @return the id from the row for the AtomicValue
+     *
+     * @throws KettleStepException if the Atomic ID is not a String
+     */
+    protected String getAtomicId(final AbstractAtomicStepData data, final Object[] row) throws KettleException {
+        final Object atomicIdFieldNameValue = row[data.getAtomicIdFieldIndex()];
+        if (atomicIdFieldNameValue instanceof String) {
+            return (String) atomicIdFieldNameValue;
+        } else {
+            throw new KettleException("Expected field " + data.getAtomicIdFieldName() + " to contain a String, but found "
+                    + atomicIdFieldNameValue.getClass());
+        }
+    }
+
+    /**
+     * Attempts to get (or initialise) the AtomicValue from {@link AtomicStorage}.
+     *
+     * This method internally may loop if {@link AbstractAtomicStepMeta#getActionIfNoAtomic()}
+     * is set to {@link ActionIfNoAtomic#Wait}.
+     *
+     * @param meta the Step Meta instance
+     * @param data the Step Data instance
+     * @param atomicId the id of the AtomicValue to get from AtomicStorage
+     *
+     * @return Either a route to target if the AtomicValue cannot be retrieved (or initialised),
+     *    or the AtomicValue if it was retrieved (or initialised).
+     */
+    protected Either<GetAtomicRouteTarget, AtomicValue> getAtomic(final AbstractAtomicStepMeta meta, final AbstractAtomicStepData data, final String atomicId) {
+        final ActionIfNoAtomic actionIfNoAtomic = meta.getActionIfNoAtomic();
+        final AtomicType atomicType = meta.getAtomicType();
+        final long waitAtomicCheckPeriod = meta.getWaitAtomicCheckPeriod();
+        final long waitAtomicTimeout = meta.getWaitAtomicTimeout();
+
+        long waitedForAtomic = 0;
+
+        while (true) {
+            final AtomicValue atomicValue;
+            if (ActionIfNoAtomic.Initialise == actionIfNoAtomic) {
+                atomicValue = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
+            } else {
+                atomicValue = data.getAtomic(atomicId, atomicType);
+            }
+
+            if (atomicValue != null) {
+                return Right(atomicValue);  // got atomicValue.. exit while loop and return it
+            }
+
+
+            /*
+                atomicValue is null, we must now check how to proceed...
+            */
+
+            if (ActionIfNoAtomic.Continue == actionIfNoAtomic) {
+                return Left(GetAtomicRouteTarget.CONTINUE);
+
+            } else if (ActionIfNoAtomic.Error == actionIfNoAtomic) {
+                return Left(GetAtomicRouteTarget.ERROR);
+
+            } else if (ActionIfNoAtomic.Wait == actionIfNoAtomic) {
+                final long sleptFor = sleepWithTimeout(waitAtomicCheckPeriod, waitedForAtomic, waitAtomicTimeout);
+                if (sleptFor > 0) {
+                    // slept OK
+                    waitedForAtomic += sleptFor;
+                    // loop to try and get the atomic again
+
+                } else if (sleptFor == 0) {
+                    // TIMEOUT reached after sleeping
+                    return Left(GetAtomicRouteTarget.TIMEOUT);
+
+                } else {
+                    // Thread INTERRUPTED whilst sleeping
+                    return Left(GetAtomicRouteTarget.THREAD_INTERRUPTED);
+                }
+            }
+        }  // end while
+    }
+
+    /**
+     * Send row to the 'Continue' output target of the step.
+     *
+     * @param meta the Step Meta instance
+     * @param data the Step Data instance
+     * @param atomicId the id of the AtomicValue
+     * @param row the row
+     * @param messageIfNoContinueTarget the exception message if there is no continue target
+     *
+     * @throws KettleException if the continue target cannot be found, or writing the row causes an error
+     */
+    protected void putRowToContinueTarget(final AbstractAtomicStepMeta meta, final AbstractAtomicStepData data, final String atomicId, final Object[] row, final String messageIfNoContinueTarget) throws KettleException {
+        this.logDebug("No Atomic object for id: {0}, and ActionIfNoAtomic == Continue", atomicId);
+
+        // is there a Continue target step?
+        final String metaContinueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
+        if (isNotEmpty(metaContinueTargetStepName)) {
+
+            // send row to the Continue output of the step
+            this.putRowTo(data.getOutputRowMeta(), row, data.getContinueOutputRowSet());
+
+            this.logDebug("No Atomic, CONTINUE: <{0}>", atomicId);
+            logLineNumber();
+
+        } else {
+            // raise an exception
+            throw new KettleException(messageIfNoContinueTarget);
+        }
+    }
+
+    /**
+     * Send row to the 'Timeout' output target of the step.
+     *
+     * @param meta the Step Meta instance
+     * @param data the Step Data instance
+     * @param row the row
+     * @param messageIfNoTimeoutTarget the exception message if there is no timeout target
+     *
+     * @throws KettleException if the timeout target cannot be found, or writing the row causes an error
+     */
+    protected void putRowToTimeoutTarget(final AbstractAtomicStepMeta meta, final AbstractAtomicStepData data, final Object[] row, final String messageIfNoTimeoutTarget) throws KettleException {
+        // is there a timeout target step?
+        final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
+        if (isNotEmpty(metaTimeoutTargetStepName)) {
+
+            // send row to the timeout output of the step
+            this.putRowTo(data.getOutputRowMeta(), row, data.getTimeoutOutputRowSet());
+
+            logLineNumber();
+
+        } else {
+            // raise an exception
+            throw new KettleException(messageIfNoTimeoutTarget);
+        }
+    }
+
+    /**
+     * Send row to the 'Error' output target of the step.
+     *
+     * @param data the Step Data instance
+     * @param row the row
+     * @param errorCode the error code
+     * @param errorMessage a description of the error
+     *
+     * @throws KettleStepException if writing the row causes an error
+     */
+    protected void putRowToErrorTarget(final AbstractAtomicStepData data, final Object[] row, final ErrorCode errorCode, final String errorMessage) throws KettleStepException {
+        // send row to the error output of the step
+        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), errorCode.getCode());
+        logLineNumber();
+    }
+
+    /**
+     * Send row to the default output target of the step.
+     *
+     * @param data the Step Data instance
+     * @param row the row
+     *
+     * @throws KettleStepException if writing the row causes an error
+     */
+    protected void putRowToDefaultTarget(final AbstractAtomicStepData data, final Object[] row) throws KettleStepException {
+        this.putRow(data.getOutputRowMeta(), row);
+        logLineNumber();
+    }
+
+    /**
+     * Sleeps and then tests if a timeout has been exceeded.
+     *
+     * @param period the period to sleep for
+     * @param timeAlreadyWaited the amount of time previously waited for, e.g. if this function is called more than
+     *                          once in a loop then the result of this function should be added to
+     *                          {@code timeAlreadyWaited} and fed back into this parameter on the next call to it.
+     *                          Can be set to 0 to indicate no previous wait.
+     * @param timeout the timeout to check for, the test is {@code timeout != -1 && (timeAlreadyWaited + period) > timeout}.
+     *                Can be set to -1 to disable any timeout check, in which case 0 will never be returned from this function.
+     *
+     * @return -1 indicates that the (sleeping) Thread was interrupted,
+     *          0 indicates that the timeout was exceeded,
+     *          a non-zero value is the {@code period} waited
+     */
+    protected long sleepWithTimeout(final long period, long timeAlreadyWaited, final long timeout) {
+        try {
+            Thread.sleep(period);
+            timeAlreadyWaited += period;
+            if (timeout != -1 && timeAlreadyWaited > timeout) {
+                return 0;
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt(); // restore interrupted flag
+            return -1;
+        }
+        return period;
+    }
+
+    protected abstract void logLineNumber();
+}

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AbstractAtomicStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AbstractAtomicStepData.java
@@ -1,0 +1,104 @@
+/**
+ * The MIT License
+ * Copyright © 2021 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package uk.gov.nationalarchives.pdi.step.atomics;
+
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.trans.step.BaseStepData;
+import org.pentaho.di.trans.step.StepDataInterface;
+
+import javax.annotation.Nullable;
+
+public abstract class AbstractAtomicStepData extends BaseStepData implements StepDataInterface {
+
+    private RowMetaInterface outputRowMeta;
+    private String atomicIdFieldName;
+    private int atomicIdFieldIndex;
+    private final OutputMap outputRowSets = new OutputMap();
+    private RowSet continueOutputRowSet = null;
+    private RowSet timeoutOutputRowSet = null;
+
+    public AbstractAtomicStepData() {
+        super();
+    }
+
+    public @Nullable
+    AtomicValue getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
+        return AtomicStorage.INSTANCE.getAtomic(id, atomicType);
+    }
+
+    public AtomicValue getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
+        return AtomicStorage.INSTANCE.getOrCreateAtomic(id, atomicType, initialValue);
+    }
+
+    public boolean removeAtomic(final String id) {
+        return AtomicStorage.INSTANCE.removeAtomic(id);
+    }
+
+    // <editor-fold desc="get/set properties">
+    public RowMetaInterface getOutputRowMeta() {
+        return outputRowMeta;
+    }
+
+    public void setOutputRowMeta(final RowMetaInterface outputRowMeta) {
+        this.outputRowMeta = outputRowMeta;
+    }
+
+    public String getAtomicIdFieldName() {
+        return atomicIdFieldName;
+    }
+
+    public void setAtomicIdFieldName(final String atomicIdFieldName) {
+        this.atomicIdFieldName = atomicIdFieldName;
+    }
+
+    public int getAtomicIdFieldIndex() {
+        return atomicIdFieldIndex;
+    }
+
+    public void setAtomicIdFieldIndex(final int atomicIdFieldIndex) {
+        this.atomicIdFieldIndex = atomicIdFieldIndex;
+    }
+
+    public RowSet getContinueOutputRowSet() {
+        return continueOutputRowSet;
+    }
+
+    public void setContinueOutputRowSet(final RowSet continueOutputRowSet) {
+        this.continueOutputRowSet = continueOutputRowSet;
+    }
+
+    public OutputMap getOutputRowSets() {
+        return outputRowSets;
+    }
+
+    public RowSet getTimeoutOutputRowSet() {
+        return timeoutOutputRowSet;
+    }
+
+    public void setTimeoutOutputRowSet(final RowSet timeoutOutputRowSet) {
+        this.timeoutOutputRowSet = timeoutOutputRowSet;
+    }
+
+    // </editor-fold>
+}

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AbstractAtomicStepMeta.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/AbstractAtomicStepMeta.java
@@ -1,0 +1,160 @@
+/**
+ * The MIT License
+ * Copyright © 2021 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package uk.gov.nationalarchives.pdi.step.atomics;
+
+import org.pentaho.di.trans.step.BaseStepMeta;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
+
+import javax.annotation.Nullable;
+
+public abstract class AbstractAtomicStepMeta extends BaseStepMeta implements StepMetaInterface {
+
+    // <editor-fold desc="settings XML element names">
+    protected static final String ELEM_NAME_ATOMIC_ID_FIELD_NAME = "atomicIdFieldName";
+    protected static final String ELEM_NAME_ATOMIC_TYPE = "atomicType";
+    protected static final String ELEM_NAME_ACTION_IF_NO_ATOMIC = "actionIfNoAtomic";
+    protected static final String ATTR_NAME_CONTINUE_TARGET_STEP = "continueTargetStep";
+    protected static final String ATTR_NAME_VALUE = "value";
+    protected static final String ELEM_NAME_ATOMIC_VALUES = "atomicValues";
+    protected static final String ELEM_NAME_ATOMIC_VALUE = "atomicValue";
+    protected static final String ATTR_NAME_TARGET_STEP = "targetStep";
+    protected static final String ATTR_NAME_CHECK_PERIOD = "checkPeriod";
+    protected static final String ATTR_NAME_TIMEOUT = "timeout";
+    protected static final String ATTR_NAME_TIMEOUT_TARGET_STEP = "timeoutTargetStep";
+    // </editor-fold>
+
+    protected static final long DEFAULT_CHECK_PERIOD = 100; // ms
+    protected static final long TIMEOUT_DISABLED = -1; // No timeout
+    protected static final long DEFAULT_TIMEOUT = TIMEOUT_DISABLED;
+
+    // <editor-fold desc="settings">
+    protected String atomicIdFieldName;
+    protected AtomicType atomicType;
+    protected ActionIfNoAtomic actionIfNoAtomic;
+    protected String continueTargetStepname;
+    @Nullable protected String initialiseAtomicValue;
+    protected long waitAtomicCheckPeriod = DEFAULT_CHECK_PERIOD;
+    protected long waitAtomicTimeout = DEFAULT_TIMEOUT;
+    protected String timeoutTargetStepname;
+    // </editor-fold>
+
+    @Nullable protected StepMeta continueTargetStep;
+    @Nullable protected StepMeta timeoutTargetStep;
+
+    @Override
+    public void setDefault() {
+        atomicIdFieldName = "";
+        atomicType = AtomicType.Boolean;
+        actionIfNoAtomic = ActionIfNoAtomic.Continue;
+        continueTargetStepname = null;
+        initialiseAtomicValue = null;
+        waitAtomicCheckPeriod = DEFAULT_CHECK_PERIOD;
+        waitAtomicTimeout = DEFAULT_TIMEOUT;
+        timeoutTargetStepname = null;
+    }
+
+    // <editor-fold desc="settings getters and setters">
+    public String getAtomicIdFieldName() {
+        return atomicIdFieldName;
+    }
+
+    public void setAtomicIdFieldName(final String atomicIdFieldName) {
+        this.atomicIdFieldName = atomicIdFieldName;
+    }
+
+    public AtomicType getAtomicType() {
+        return atomicType;
+    }
+
+    public void setAtomicType(final AtomicType atomicType) {
+        this.atomicType = atomicType;
+    }
+
+    public ActionIfNoAtomic getActionIfNoAtomic() {
+        return actionIfNoAtomic;
+    }
+
+    public void setActionIfNoAtomic(final ActionIfNoAtomic actionIfNoAtomic) {
+        this.actionIfNoAtomic = actionIfNoAtomic;
+    }
+
+    public String getContinueTargetStepname() {
+        return continueTargetStepname;
+    }
+
+    public void setContinueTargetStepname(final String continueTargetStepname) {
+        this.continueTargetStepname = continueTargetStepname;
+    }
+
+    @Nullable public StepMeta getContinueTargetStep() {
+        return continueTargetStep;
+    }
+
+    public void setContinueTargetStep(@Nullable final StepMeta continueTargetStep) {
+        this.continueTargetStep = continueTargetStep;
+    }
+
+    public @Nullable String getInitialiseAtomicValue() {
+        return initialiseAtomicValue;
+    }
+
+    public void setInitialiseAtomicValue(@Nullable final String initialiseAtomicValue) {
+        this.initialiseAtomicValue = initialiseAtomicValue;
+    }
+
+    public long getWaitAtomicCheckPeriod() {
+        return waitAtomicCheckPeriod;
+    }
+
+    public void setWaitAtomicCheckPeriod(final long waitAtomicCheckPeriod) {
+        this.waitAtomicCheckPeriod = waitAtomicCheckPeriod;
+    }
+
+    public long getWaitAtomicTimeout() {
+        return waitAtomicTimeout;
+    }
+
+    public void setWaitAtomicTimeout(final long waitAtomicTimeout) {
+        this.waitAtomicTimeout = waitAtomicTimeout;
+    }
+
+    public String getTimeoutTargetStepname() {
+        return timeoutTargetStepname;
+    }
+
+    public void setTimeoutTargetStepname(final String timeoutTargetStepname) {
+        this.timeoutTargetStepname = timeoutTargetStepname;
+    }
+
+    public StepMeta getTimeoutTargetStep() {
+        return timeoutTargetStep;
+    }
+
+    public void setTimeoutTargetStep(final StepMeta timeoutTargetStep) {
+        this.timeoutTargetStep = timeoutTargetStep;
+    }
+
+    // </editor-fold>
+
+}

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/ErrorCode.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/ErrorCode.java
@@ -26,7 +26,7 @@ package uk.gov.nationalarchives.pdi.step.atomics;
  * Error Codes which can be produced by the Steps
  * when an error occurs.
  */
-public enum ErrorCodes {
+public enum ErrorCode {
     NO_SUCH_ATOMIC("NSA1", "No such Atomic Value"),
     NO_SUCH_ATOMIC_WAIT_TIMEOUT("NSA2", "Timeout reached when waiting for Atomic Value creation"),
     NO_SUCH_ATOMIC_WAIT_INTERRUPTED("NSA3", "Thread interrupted whilst waiting for Atomic Value creation"),
@@ -37,7 +37,7 @@ public enum ErrorCodes {
     private final String code;
     private final String description;
 
-    ErrorCodes(final String code, final  String description) {
+    ErrorCode(final String code, final  String description) {
         this.code = code;
         this.description = description;
     }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/OutputMap.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/OutputMap.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package uk.gov.nationalarchives.pdi.step.atomics.compareandset;
+package uk.gov.nationalarchives.pdi.step.atomics;
 
 import org.pentaho.di.core.RowSet;
 

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/Util.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/Util.java
@@ -59,6 +59,38 @@ public interface Util {
     }
 
     /**
+     * Given a String, returns a the String "null" if the string is null, or
+     * otherwise the String.
+     *
+     * @param s a String
+     *
+     * @return the String "null" if {@code s == null}, else a string.
+     */
+    static String strNullIfNull(@Nullable final String s) {
+        if (s == null) {
+            return "null";
+        } else {
+            return s;
+        }
+    }
+
+    /**
+     * Given a String, returns null if the String is "null" or null, or
+     * otherwise the String.
+     *
+     * @param s a String
+     *
+     * @return null if the String is "null" or null, else a string.
+     */
+    static String nullIfStrNull(@Nullable final String s) {
+        if (s == null || "null".equals(s)) {
+            return null;
+        } else {
+            return s;
+        }
+    }
+
+    /**
      * Returns true if the String is either null or empty.
      *
      * @param s a String

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -95,7 +95,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
             }
 
 
-            // when atomicObj null...
+            // when atomicValue null...
 
             if (ActionIfNoAtomic.Continue == actionIfNoAtomic) {
                 // send row to the 'Continue' output of the step
@@ -148,7 +148,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
             }
         }  // end while
 
-        // At this point we have an atomicObj
+        // At this point we have an atomicValue
         boolean atomicIsEqual = false;
 
         final long waitLoopCheckPeriod = meta.getWaitLoopCheckPeriod();

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -45,9 +45,15 @@ import static uk.gov.nationalarchives.pdi.step.atomics.Util.*;
 
 public class AwaitStep extends BaseStep implements StepInterface {
 
-    private enum RouteTarget {
+    private enum GetAtomicRouteTarget {
         CONTINUE,
         ERROR,
+        TIMEOUT,
+        THREAD_INTERRUPTED
+    }
+
+    private enum AwaitAtomicRouteTarget {
+        DEFAULT,
         TIMEOUT,
         THREAD_INTERRUPTED
     }
@@ -64,7 +70,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
     @Override
     public boolean processRow(final StepMetaInterface smi, final StepDataInterface sdi) throws KettleException {
 
-        Object[] row = getRow(); // try and get a row
+        final Object[] row = getRow(); // try and get a row
         if (row == null) {
             // no more rows...
             setOutputDone();
@@ -85,157 +91,75 @@ public class AwaitStep extends BaseStep implements StepInterface {
 
         final String atomicId = getAtomicId(data, row);
 
-        // get (or initialise) the AtomicValue
-        final Either<RouteTarget, AtomicValue> routeOrAtomic = getAtomic(meta, data, atomicId);
+        // 1. get (or initialise) the AtomicValue
+        final Either<GetAtomicRouteTarget, AtomicValue> routeOrAtomic = getAtomic(meta, data, atomicId);
         if (routeOrAtomic.isLeft()) {
             // could not get (or initialise) AtomicValue, so route row to specific output target...
-            final RouteTarget route = routeOrAtomic.left().get();
+            final GetAtomicRouteTarget route = routeOrAtomic.left().get();
             switch (route) {
                 case CONTINUE:
-                    sendRowToContinueTarget(meta, data, atomicId, row);
+                    putRowToContinueTarget(meta, data, atomicId, row);
                     return true;
 
                 case ERROR:
-                    sendRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC, "No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error");
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC, "No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error");
                     return true;
 
                 case TIMEOUT:
-                    sendRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT, "Timeout (" + meta.getWaitAtomicTimeout() + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
+                    // NOTE: this is intentionally sent to the error target at this stage, the timeout target is reserved for the await value part further below
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT, "Timeout (" + meta.getWaitAtomicTimeout() + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
                     return true;
 
                 case THREAD_INTERRUPTED:
-                    sendRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED, "Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED, "Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
                     return true;
             }
         }
 
         // At this point we have an AtomicValue
-        AtomicValue atomicValue = routeOrAtomic.right().get();
+        final AtomicValue atomicValue = routeOrAtomic.right().get();
 
-        final AtomicType atomicType = meta.getAtomicType();
+        // 2. Check/Wait until the AtomicValue reaches one of the await values, and then get the target
+        final Either<AwaitAtomicRouteTarget, AwaitTarget> routeOrAwaitTarget = awaitAndGetTarget(meta, data, atomicId, atomicValue);
+        if (routeOrAwaitTarget.isLeft()) {
+            // AtomicValue never reached one of the await values, so route row to specific failure output target...
+            final AwaitAtomicRouteTarget route = routeOrAwaitTarget.left().get();
+            switch (route) {
+                case DEFAULT:
+                    putRowToDefaultTarget(data, row);
+                    return true;
 
-        AwaitTarget awaitTarget = null;
-        final List<AwaitTarget> awaitValues = meta.getAwaitValues();
-        if (awaitValues != null && !awaitValues.isEmpty()) {
-            final long waitLoopCheckPeriod = meta.getWaitLoopCheckPeriod();
-            final long waitLoopTimeout = meta.getWaitLoopTimeout();
+                case TIMEOUT:
+                    putRowToTimeoutTarget(meta, data, row);
+                    return true;
 
-            // check if one of the options is to await `null`
-            AwaitTarget awaitNullTarget = null;
-            for (final AwaitTarget awaitValue : awaitValues) {
-                if (awaitValue.getAtomicValue() == null) {
-                    awaitNullTarget = awaitValue;
-                    break;
-                }
+                case THREAD_INTERRUPTED:
+                    putRowToErrorTarget(data, row, ErrorCode.AWAIT_ATOMIC_WAIT_INTERRUPTED, "Thread interrupted whilst waiting for Atomic value for id: " + atomicId);
+                    return true;
             }
-
-            boolean atomicIsEqual = false;
-            long waited = 0;
-            while (true) {
-
-                if (awaitNullTarget != null && atomicValue == null) {
-                    // null is a valid value to check for, i.e. already discarded
-                    atomicIsEqual = true;
-                    awaitTarget = awaitNullTarget;
-
-                } else {
-                    atomicIsEqual = false;
-
-                    for (final AwaitTarget awaitValue : awaitValues) {
-                        @Nullable final String awaitAtomicValue = awaitValue.getAtomicValue();
-
-                        if (awaitAtomicValue == null) {
-                            // handled above in awaitNullTarget logic
-                            continue;
-
-                        } else if (AtomicType.Boolean == atomicType) {
-                            final AtomicBooleanValue atomicBoolean = (AtomicBooleanValue) atomicValue;
-                            final boolean awaitValueBoolean = Boolean.parseBoolean(awaitAtomicValue);
-                            atomicIsEqual = awaitValueBoolean == atomicBoolean.get();
-
-                        } else if (AtomicType.Integer == atomicType) {
-                            final int awaitValueInt = Integer.parseInt(awaitAtomicValue);
-                            final AtomicIntegerValue atomicInteger = (AtomicIntegerValue) atomicValue;
-                            atomicIsEqual = awaitValueInt == atomicInteger.get();
-
-                        } else {
-                            throw new IllegalArgumentException("Unknown AtomicType: " + atomicType.name());
-                        }
-
-                        if (atomicIsEqual) {
-                            awaitTarget = awaitValue;
-                            break; // atomic value is equal to expected, exit for loop
-                        }
-
-                    }  // end for
-                }
-
-
-                if (atomicIsEqual) {
-                    break; // atomic value is equal to expected, exit while loop
-                }
-
-                // wait and check again
-                try {
-                    Thread.sleep(waitLoopCheckPeriod);
-                    waited += waitLoopCheckPeriod;
-                    if (waitLoopTimeout != -1 && waited > waitLoopTimeout) {
-                        // TIMEOUT reached!
-
-                        // is there a timeout target step?
-                        final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
-                        if (isNotEmpty(metaTimeoutTargetStepName)) {
-
-                            // send row to the timeout output of the step
-                            this.putRowTo(data.getOutputRowMeta(), row, data.getTimeoutOutputRowSet());
-                            logLineNumber();
-
-                            return true; // row done!
-
-                        } else {
-                            // raise an exception
-                            throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.NoTimeoutTargetStep"));
-                        }
-                    }
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt(); // restore interrupted flag
-                    // send row to the error output of the step
-                    final String errorMessage = "Thread interrupted whilst waiting for Atomic value for id: " + atomicId;
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.AWAIT_ATOMIC_WAIT_INTERRUPTED.getCode());
-                    logLineNumber();
-                    return true; // row done!
-                }
-
-                // refresh the atomic object
-                atomicValue = data.getAtomic(atomicId, atomicType);
-
-            }  // end while
         }
 
-        if (awaitTarget != null) {
-            // send to specific target for Await success
-            final Set<RowSet> atomicValueTargetRowSets = data.getAtomicValueOutputRowSets().get(awaitTarget.getAtomicValue());
-            if (atomicValueTargetRowSets == null || atomicValueTargetRowSets.isEmpty()) {
-                throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindTargetRowSetForStep", new Object[] { awaitTarget.getTargetStep() != null ? awaitTarget.getTargetStep().getName() : awaitTarget.getTargetStepname() }));
+        // At this point we have an AwaitTarget, i.e. the AtomicValue matches an await value
+        final AwaitTarget awaitTarget = routeOrAwaitTarget.right().get();
+
+        // We now send the input row to specific targets for Await success
+        final Set<RowSet> atomicValueTargetRowSets = data.getAtomicValueOutputRowSets().get(awaitTarget.getAtomicValue());
+        if (atomicValueTargetRowSets == null || atomicValueTargetRowSets.isEmpty()) {
+            throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindTargetRowSetForStep", new Object[] { awaitTarget.getTargetStep() != null ? awaitTarget.getTargetStep().getName() : awaitTarget.getTargetStepname() }));
+        }
+
+        // send the row to the success targets
+        for (final RowSet awaitValueTargetRowSet : atomicValueTargetRowSets) {
+            this.putRowTo(data.getOutputRowMeta(), row, awaitValueTargetRowSet);
+        }
+
+        this.logDebug("Await DONE: <{0}>[{1}]", atomicId, strNullIfNull(nullIfEmpty(awaitTarget.getAtomicValue())));
+
+        if (awaitTarget.isDiscardAtomic()) {
+            // discard the atomic if user requested to do so
+            if (!data.removeAtomic(atomicId)) {
+                this.logError("Unable to discard Atomic with ID: {0}", atomicId);
             }
-
-            for (final RowSet awaitValueTargetRowSet : atomicValueTargetRowSets) {
-                this.putRowTo(data.getOutputRowMeta(), row, awaitValueTargetRowSet);
-            }
-
-            this.logDebug("Await DONE: <{0}>[{1}]", atomicId, strNullIfNull(nullIfEmpty(awaitTarget.getAtomicValue())));
-
-            if (awaitTarget.isDiscardAtomic()) {
-                // discard the atomic if requested to do so
-                if (!data.removeAtomic(atomicId)) {
-                    this.logError("Unable to discard Atomic with ID: {0}", atomicId);
-                }
-            }
-
-
-        } else {
-            //send to default output if no Await Target
-            this.putRow(data.getOutputRowMeta(), row);
         }
 
         logLineNumber();
@@ -243,6 +167,16 @@ public class AwaitStep extends BaseStep implements StepInterface {
         return true;  // row done!
     }
 
+    /**
+     * Get the Atomic ID from the input row.
+     *
+     * @param data the Await Step Data instance
+     * @param row the row
+     *
+     * @return the id from the row for the AtomicValue
+     *
+     * @throws KettleStepException if the Atomic ID is not a String
+     */
     private String getAtomicId(final AwaitStepData data, final Object[] row) throws KettleException {
         final Object atomicIdFieldNameValue = row[data.getAtomicIdFieldIndex()];
         if (atomicIdFieldNameValue instanceof String) {
@@ -254,15 +188,19 @@ public class AwaitStep extends BaseStep implements StepInterface {
     }
 
     /**
-     * Attempts to get the AtomicValue from {@link AtomicStorage}.
+     * Attempts to get (or initialise) the AtomicValue from {@link AtomicStorage}.
      *
      * This method internally may loop if {@link AwaitStepMeta#getActionIfNoAtomic()}
      * is set to {@link ActionIfNoAtomic#Wait}.
      *
+     * @param meta the Await Step Meta instance
+     * @param data the Await Step Data instance
+     * @param atomicId the id of the AtomicValue to get from AtomicStorage
+     *
      * @return Either a route to target if the AtomicValue cannot be retrieved (or initialised),
      *    or the AtomicValue if it was retrieved (or initialised).
      */
-    private Either<RouteTarget, AtomicValue> getAtomic(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId) {
+    private Either<GetAtomicRouteTarget, AtomicValue> getAtomic(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId) {
         final ActionIfNoAtomic actionIfNoAtomic = meta.getActionIfNoAtomic();
         final AtomicType atomicType = meta.getAtomicType();
         final long waitAtomicCheckPeriod = meta.getWaitAtomicCheckPeriod();
@@ -279,7 +217,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
             }
 
             if (atomicValue != null) {
-                return Right(atomicValue);  // exit while loop
+                return Right(atomicValue);  // got atomicValue.. exit while loop and return it
             }
 
 
@@ -288,32 +226,130 @@ public class AwaitStep extends BaseStep implements StepInterface {
             */
 
             if (ActionIfNoAtomic.Continue == actionIfNoAtomic) {
-                return Left(RouteTarget.CONTINUE);
+                return Left(GetAtomicRouteTarget.CONTINUE);
 
             } else if (ActionIfNoAtomic.Error == actionIfNoAtomic) {
-                return Left(RouteTarget.ERROR);
+                return Left(GetAtomicRouteTarget.ERROR);
 
             } else if (ActionIfNoAtomic.Wait == actionIfNoAtomic) {
                 final long sleptFor = sleepWithTimeout(waitAtomicCheckPeriod, waitedForAtomic, waitAtomicTimeout);
                 if (sleptFor > 0) {
                     // slept OK
                     waitedForAtomic += sleptFor;
-                    continue;  // loop to try and get the atomic again
+                    // loop to try and get the atomic again
 
                 } else if (sleptFor == 0) {
                     // TIMEOUT reached after sleeping
-                    return Left(RouteTarget.TIMEOUT);
+                    return Left(GetAtomicRouteTarget.TIMEOUT);
 
                 } else {
                     // Thread INTERRUPTED whilst sleeping
-                    return Left(RouteTarget.THREAD_INTERRUPTED);
+                    return Left(GetAtomicRouteTarget.THREAD_INTERRUPTED);
                 }
             }
         }  // end while
     }
 
-    private void sendRowToContinueTarget(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId, final Object[] row) throws KettleException {
-        // send row to the 'Continue' output of the step
+    /**
+     * Attempts to wait for the AtomicValue to become one of the await values.
+     *
+     * This method internally will loop approximately every {@link AwaitStepMeta#getWaitLoopCheckPeriod()}
+     * until the AtomicValue matches one of the await values, or {@link AwaitStepMeta#getWaitLoopTimeout()} is reached.
+     *
+     * @param meta the Await Step Meta instance
+     * @param data the Await Step Data instance
+     * @param atomicId the id of the AtomicValue
+     * @param atomicValue the AtomicValue on which we await to reach a specific value
+     *
+     * @return Either a route to target if the AtomicValue never matches one of the await values,
+     *    or the AwaitTarget to route the output to when it matches one of the await values.
+     */
+    private Either<AwaitAtomicRouteTarget, AwaitTarget> awaitAndGetTarget(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId, AtomicValue atomicValue) {
+        final AtomicType atomicType = meta.getAtomicType();
+        final List<AwaitTarget> awaitValues = meta.getAwaitValues();
+        if (awaitValues != null && !awaitValues.isEmpty()) {
+
+            // check if one of the options is to await for `null`
+            final AwaitTarget awaitNullTarget = AwaitTarget.findAwaitTargetForNullValue(awaitValues);
+
+            final long waitLoopCheckPeriod = meta.getWaitLoopCheckPeriod();
+            final long waitLoopTimeout = meta.getWaitLoopTimeout();
+
+            long waited = 0;
+            while (true) {
+
+                if (awaitNullTarget != null && atomicValue == null) {
+                    // null is a valid value to check for, i.e. already discarded
+                    return Right(awaitNullTarget);
+
+                } else {
+
+                    for (final AwaitTarget awaitValue : awaitValues) {
+                        @Nullable final String awaitAtomicValue = awaitValue.getAtomicValue();
+
+                        if (awaitAtomicValue == null) {
+                            // handled above in awaitNullTarget logic
+                            continue;
+
+                        } else if (AtomicType.Boolean == atomicType) {
+                            final AtomicBooleanValue atomicBoolean = (AtomicBooleanValue) atomicValue;
+                            final boolean awaitValueBoolean = Boolean.parseBoolean(awaitAtomicValue);
+                            if (awaitValueBoolean == atomicBoolean.get()) {
+                                return Right(awaitValue);
+                            }
+
+                        } else if (AtomicType.Integer == atomicType) {
+                            final int awaitValueInt = Integer.parseInt(awaitAtomicValue);
+                            final AtomicIntegerValue atomicInteger = (AtomicIntegerValue) atomicValue;
+                            if (awaitValueInt == atomicInteger.get()) {
+                                return Right(awaitValue);
+                            }
+
+                        } else {
+                            throw new IllegalArgumentException("Unknown AtomicType: " + atomicType.name());
+                        }
+
+                    }  // end for
+                }
+
+                // wait and check again
+                final long sleptFor = sleepWithTimeout(waitLoopCheckPeriod, waited, waitLoopTimeout);
+
+                if (sleptFor > 0) {
+                    // slept OK
+                    waited += sleptFor;
+                    // loop to try and match the atomic value again
+
+                }  else if (sleptFor == 0) {
+                    // TIMEOUT reached after sleeping
+                    return Left(AwaitAtomicRouteTarget.TIMEOUT);
+
+                } else {
+                    // Thread INTERRUPTED whilst sleeping
+                    return Left(AwaitAtomicRouteTarget.THREAD_INTERRUPTED);
+                }
+
+                // refresh the atomic object
+                atomicValue = data.getAtomic(atomicId, atomicType);
+
+            }  // end while
+        }
+
+        // send to default output if no Await Target
+        return Left(AwaitAtomicRouteTarget.DEFAULT);
+    }
+
+    /**
+     * Send row to the 'Continue' output target of the step.
+     *
+     * @param meta the Await Step Meta instance
+     * @param data the Await Step Data instance
+     * @param atomicId the id of the AtomicValue
+     * @param row the row
+     *
+     * @throws KettleException if the continue target cannot be found, or writing the row causes an error
+     */
+    private void putRowToContinueTarget(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId, final Object[] row) throws KettleException {
         this.logDebug("Await No Atomic object for id: {0}, and ActionIfNoAtomic == Continue", atomicId);
 
         // is there a Continue target step?
@@ -332,9 +368,57 @@ public class AwaitStep extends BaseStep implements StepInterface {
         }
     }
 
-    private void sendRowToErrorTarget(final AwaitStepData data, final Object[] row, final ErrorCode errorCode, final String errorMessage) throws KettleStepException {
+    /**
+     * Send row to the 'Timeout' output target of the step.
+     *
+     * @param meta the Await Step Meta instance
+     * @param data the Await Step Data instance
+     * @param row the row
+     *
+     * @throws KettleException if the timeout target cannot be found, or writing the row causes an error
+     */
+    private void putRowToTimeoutTarget(final AwaitStepMeta meta, final AwaitStepData data, final Object[] row) throws KettleException {
+        // is there a timeout target step?
+        final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
+        if (isNotEmpty(metaTimeoutTargetStepName)) {
+
+            // send row to the timeout output of the step
+            this.putRowTo(data.getOutputRowMeta(), row, data.getTimeoutOutputRowSet());
+
+            logLineNumber();
+
+        } else {
+            // raise an exception
+            throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.NoTimeoutTargetStep"));
+        }
+    }
+
+    /**
+     * Send row to the 'Error' output target of the step.
+     *
+     * @param data the Await Step Data instance
+     * @param row the row
+     * @param errorCode the error code
+     * @param errorMessage a description of the error
+     *
+     * @throws KettleStepException if writing the row causes an error
+     */
+    private void putRowToErrorTarget(final AwaitStepData data, final Object[] row, final ErrorCode errorCode, final String errorMessage) throws KettleStepException {
         // send row to the error output of the step
         this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), errorCode.getCode());
+        logLineNumber();
+    }
+
+    /**
+     * Send row to the default output target of the step.
+     *
+     * @param data the Await Step Data instance
+     * @param row the row
+     *
+     * @throws KettleStepException if writing the row causes an error
+     */
+    private void putRowToDefaultTarget(final AwaitStepData data, final Object[] row) throws KettleStepException {
+        this.putRow(data.getOutputRowMeta(), row);
         logLineNumber();
     }
 
@@ -415,64 +499,59 @@ public class AwaitStep extends BaseStep implements StepInterface {
             throw new KettleException(BaseMessages.getString( PKG, "AwaitStep.Exception.UnableToFindFieldName", atomicIdFieldName));
         }
 
-//        try {
+        final StepIOMetaInterface ioMeta = meta.getStepIOMeta();
 
-            final StepIOMetaInterface ioMeta = meta.getStepIOMeta();
-
-            // There is one or many CAS target for each target stream.
-            final List<StreamInterface> targetStreams = ioMeta.getTargetStreams();
-            for (int i = 0; i < targetStreams.size(); i++) {
-                final Object subject = targetStreams.get(i).getSubject();
-                if (subject == null) {
-                    continue;  // Skip over default option
-                }
-                if (!(subject instanceof AwaitTarget)) {
-                    continue;  // Skip over other target type
-                }
-
-                final AwaitTarget awaitValue = (AwaitTarget) subject;
-
-                final String awaitTargetStepName = awaitValue.getTargetStep() != null ? awaitValue.getTargetStep().getName() : awaitValue.getTargetStepname();
-                if (isNullOrEmpty(awaitTargetStepName)) {
-                    throw new KettleException(BaseMessages.getString(
-                            PKG, "AwaitStep.Log.NoTargetStepSpecifiedForValue", strNullIfNull(nullIfEmpty(awaitValue.getAtomicValue()))));
-                }
-
-                if (!IGNORE_STEPNAME_FOR_TEST.equals(awaitTargetStepName)) {
-                    final RowSet rowSet = findOutputRowSet(awaitTargetStepName);
-                    if (rowSet == null) {
-                        throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindAtomicValueTargetRowSetForStep", new Object[]{awaitTargetStepName}));
-                    }
-
-                    // store the await value and the rowset
-                    data.getAtomicValueOutputRowSets().put(awaitValue.getAtomicValue(), rowSet);
-                }
+        // There is one or many CAS target for each target stream.
+        final List<StreamInterface> targetStreams = ioMeta.getTargetStreams();
+        for (final StreamInterface targetStream : targetStreams) {
+            final Object subject = targetStream.getSubject();
+            if (subject == null) {
+                continue;  // Skip over default option
+            }
+            if (!(subject instanceof AwaitTarget)) {
+                continue;  // Skip over other target type
             }
 
+            final AwaitTarget awaitValue = (AwaitTarget) subject;
 
-            // The ioMeta object also has optional target streams for: continue, and timeout.
-
-            final String metaContinueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
-            if (isNotEmpty(metaContinueTargetStepName)) {
-                final RowSet rowSet = findOutputRowSet(metaContinueTargetStepName);
-                if (rowSet != null) {
-                    data.setContinueOutputRowSet(rowSet);
-                } else {
-                    throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindContinueTargetRowSetForStep", new Object[]{ metaContinueTargetStepName }));
-                }
+            final String awaitTargetStepName = awaitValue.getTargetStep() != null ? awaitValue.getTargetStep().getName() : awaitValue.getTargetStepname();
+            if (isNullOrEmpty(awaitTargetStepName)) {
+                throw new KettleException(BaseMessages.getString(
+                        PKG, "AwaitStep.Log.NoTargetStepSpecifiedForValue", strNullIfNull(nullIfEmpty(awaitValue.getAtomicValue()))));
             }
 
-            final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
-            if (isNotEmpty(metaTimeoutTargetStepName)) {
-                final RowSet rowSet = findOutputRowSet(metaTimeoutTargetStepName);
-                if (rowSet != null) {
-                    data.setTimeoutOutputRowSet(rowSet);
-                } else {
-                    throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindTimeoutTargetRowSetForStep", new Object[] { metaTimeoutTargetStepName }));
+            if (!IGNORE_STEPNAME_FOR_TEST.equals(awaitTargetStepName)) {
+                final RowSet rowSet = findOutputRowSet(awaitTargetStepName);
+                if (rowSet == null) {
+                    throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindAtomicValueTargetRowSetForStep", new Object[]{awaitTargetStepName}));
                 }
+
+                // store the await value and the rowset
+                data.getAtomicValueOutputRowSets().put(awaitValue.getAtomicValue(), rowSet);
             }
-//        } catch (final Exception e) {
-//            throw new KettleException(e);
-//        }
+        }
+
+
+        // The ioMeta object also has optional target streams for: continue, and timeout.
+
+        final String metaContinueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
+        if (isNotEmpty(metaContinueTargetStepName)) {
+            final RowSet rowSet = findOutputRowSet(metaContinueTargetStepName);
+            if (rowSet != null) {
+                data.setContinueOutputRowSet(rowSet);
+            } else {
+                throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindContinueTargetRowSetForStep", new Object[]{ metaContinueTargetStepName }));
+            }
+        }
+
+        final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
+        if (isNotEmpty(metaTimeoutTargetStepName)) {
+            final RowSet rowSet = findOutputRowSet(metaTimeoutTargetStepName);
+            if (rowSet != null) {
+                data.setTimeoutOutputRowSet(rowSet);
+            } else {
+                throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindTimeoutTargetRowSetForStep", new Object[] { metaTimeoutTargetStepName }));
+            }
+        }
     }
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -128,7 +128,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
             } else if (ActionIfNoAtomic.Error == actionIfNoAtomic) {
                 // send row to the error output of the step
                 final String errorMessage = "No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error";
-                this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.NO_SUCH_ATOMIC.getCode());
+                this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC.getCode());
                 logLineNumber();
                 return true; // row done!
 
@@ -140,7 +140,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
                         // TIMEOUT reached!
                         // send row to the error output of the step
                         final String errorMessage = "Timeout (" + waitAtomicTimeout + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait";
-                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.NO_SUCH_ATOMIC_WAIT_TIMEOUT.getCode());
+                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT.getCode());
                         logLineNumber();
                         return true; // row done!
                     }
@@ -148,7 +148,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
                     Thread.currentThread().interrupt(); // restore interrupted flag
                     // send row to the error output of the step
                     final String errorMessage = "Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait";
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.NO_SUCH_ATOMIC_WAIT_INTERRUPTED.getCode());
+                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED.getCode());
                     logLineNumber();
                     return true; // row done!
                 }
@@ -243,7 +243,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
                     Thread.currentThread().interrupt(); // restore interrupted flag
                     // send row to the error output of the step
                     final String errorMessage = "Thread interrupted whilst waiting for Atomic value for id: " + atomicId;
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.AWAIT_ATOMIC_WAIT_INTERRUPTED.getCode());
+                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.AWAIT_ATOMIC_WAIT_INTERRUPTED.getCode());
                     logLineNumber();
                     return true; // row done!
                 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -143,7 +143,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
         final AwaitTarget awaitTarget = routeOrAwaitTarget.right().get();
 
         // We now send the input row to specific targets for Await success
-        final Set<RowSet> atomicValueTargetRowSets = data.getAtomicValueOutputRowSets().get(awaitTarget.getAtomicValue());
+        final Set<RowSet> atomicValueTargetRowSets = data.getOutputRowSets().get(awaitTarget.getAtomicValue());
         if (atomicValueTargetRowSets == null || atomicValueTargetRowSets.isEmpty()) {
             throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.UnableToFindTargetRowSetForStep", new Object[] { awaitTarget.getTargetStep() != null ? awaitTarget.getTargetStep().getName() : awaitTarget.getTargetStepname() }));
         }
@@ -527,7 +527,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
                 }
 
                 // store the await value and the rowset
-                data.getAtomicValueOutputRowSets().put(awaitValue.getAtomicValue(), rowSet);
+                data.getOutputRowSets().put(awaitValue.getAtomicValue(), rowSet);
             }
         }
 

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -102,16 +102,16 @@ public class AwaitStep extends BaseStep implements StepInterface {
                     return true;
 
                 case ERROR:
-                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC, "No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error");
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC, "Await No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error");
                     return true;
 
                 case TIMEOUT:
                     // NOTE: this is intentionally sent to the error target at this stage, the timeout target is reserved for the await value part further below
-                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT, "Timeout (" + meta.getWaitAtomicTimeout() + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT, "Await Timeout (" + meta.getWaitAtomicTimeout() + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
                     return true;
 
                 case THREAD_INTERRUPTED:
-                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED, "Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED, "Await Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
                     return true;
             }
         }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -25,7 +25,6 @@ package uk.gov.nationalarchives.pdi.step.atomics.await;
 import com.evolvedbinary.j8fu.Either;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.exception.KettleStepException;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.core.util.Utils;
 import org.pentaho.di.i18n.BaseMessages;
@@ -43,14 +42,7 @@ import static com.evolvedbinary.j8fu.Either.Left;
 import static com.evolvedbinary.j8fu.Either.Right;
 import static uk.gov.nationalarchives.pdi.step.atomics.Util.*;
 
-public class AwaitStep extends BaseStep implements StepInterface {
-
-    private enum GetAtomicRouteTarget {
-        CONTINUE,
-        ERROR,
-        TIMEOUT,
-        THREAD_INTERRUPTED
-    }
+public class AwaitStep extends AbstractAtomicStep {
 
     private enum AwaitAtomicRouteTarget {
         DEFAULT,
@@ -98,7 +90,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
             final GetAtomicRouteTarget route = routeOrAtomic.left().get();
             switch (route) {
                 case CONTINUE:
-                    putRowToContinueTarget(meta, data, atomicId, row);
+                    putRowToContinueTarget(meta, data, atomicId, row, BaseMessages.getString(PKG, "AwaitStep.Log.NoContinueTargetStep"));
                     return true;
 
                 case ERROR:
@@ -130,7 +122,7 @@ public class AwaitStep extends BaseStep implements StepInterface {
                     return true;
 
                 case TIMEOUT:
-                    putRowToTimeoutTarget(meta, data, row);
+                    putRowToTimeoutTarget(meta, data, row, BaseMessages.getString(PKG, "AwaitStep.Log.NoTimeoutTargetStep"));
                     return true;
 
                 case THREAD_INTERRUPTED:
@@ -165,89 +157,6 @@ public class AwaitStep extends BaseStep implements StepInterface {
         logLineNumber();
 
         return true;  // row done!
-    }
-
-    /**
-     * Get the Atomic ID from the input row.
-     *
-     * @param data the Await Step Data instance
-     * @param row the row
-     *
-     * @return the id from the row for the AtomicValue
-     *
-     * @throws KettleStepException if the Atomic ID is not a String
-     */
-    private String getAtomicId(final AwaitStepData data, final Object[] row) throws KettleException {
-        final Object atomicIdFieldNameValue = row[data.getAtomicIdFieldIndex()];
-        if (atomicIdFieldNameValue instanceof String) {
-            return (String) atomicIdFieldNameValue;
-        } else {
-            throw new KettleException("Expected field " + data.getAtomicIdFieldName() + " to contain a String, but found "
-                    + atomicIdFieldNameValue.getClass());
-        }
-    }
-
-    /**
-     * Attempts to get (or initialise) the AtomicValue from {@link AtomicStorage}.
-     *
-     * This method internally may loop if {@link AwaitStepMeta#getActionIfNoAtomic()}
-     * is set to {@link ActionIfNoAtomic#Wait}.
-     *
-     * @param meta the Await Step Meta instance
-     * @param data the Await Step Data instance
-     * @param atomicId the id of the AtomicValue to get from AtomicStorage
-     *
-     * @return Either a route to target if the AtomicValue cannot be retrieved (or initialised),
-     *    or the AtomicValue if it was retrieved (or initialised).
-     */
-    private Either<GetAtomicRouteTarget, AtomicValue> getAtomic(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId) {
-        final ActionIfNoAtomic actionIfNoAtomic = meta.getActionIfNoAtomic();
-        final AtomicType atomicType = meta.getAtomicType();
-        final long waitAtomicCheckPeriod = meta.getWaitAtomicCheckPeriod();
-        final long waitAtomicTimeout = meta.getWaitAtomicTimeout();
-
-        long waitedForAtomic = 0;
-
-        while (true) {
-            final AtomicValue atomicValue;
-            if (ActionIfNoAtomic.Initialise == actionIfNoAtomic) {
-                atomicValue = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
-            } else {
-                atomicValue = data.getAtomic(atomicId, atomicType);
-            }
-
-            if (atomicValue != null) {
-                return Right(atomicValue);  // got atomicValue.. exit while loop and return it
-            }
-
-
-            /*
-                atomicValue is null, we must now check how to proceed...
-            */
-
-            if (ActionIfNoAtomic.Continue == actionIfNoAtomic) {
-                return Left(GetAtomicRouteTarget.CONTINUE);
-
-            } else if (ActionIfNoAtomic.Error == actionIfNoAtomic) {
-                return Left(GetAtomicRouteTarget.ERROR);
-
-            } else if (ActionIfNoAtomic.Wait == actionIfNoAtomic) {
-                final long sleptFor = sleepWithTimeout(waitAtomicCheckPeriod, waitedForAtomic, waitAtomicTimeout);
-                if (sleptFor > 0) {
-                    // slept OK
-                    waitedForAtomic += sleptFor;
-                    // loop to try and get the atomic again
-
-                } else if (sleptFor == 0) {
-                    // TIMEOUT reached after sleeping
-                    return Left(GetAtomicRouteTarget.TIMEOUT);
-
-                } else {
-                    // Thread INTERRUPTED whilst sleeping
-                    return Left(GetAtomicRouteTarget.THREAD_INTERRUPTED);
-                }
-            }
-        }  // end while
     }
 
     /**
@@ -339,119 +248,8 @@ public class AwaitStep extends BaseStep implements StepInterface {
         return Left(AwaitAtomicRouteTarget.DEFAULT);
     }
 
-    /**
-     * Send row to the 'Continue' output target of the step.
-     *
-     * @param meta the Await Step Meta instance
-     * @param data the Await Step Data instance
-     * @param atomicId the id of the AtomicValue
-     * @param row the row
-     *
-     * @throws KettleException if the continue target cannot be found, or writing the row causes an error
-     */
-    private void putRowToContinueTarget(final AwaitStepMeta meta, final AwaitStepData data, final String atomicId, final Object[] row) throws KettleException {
-        this.logDebug("Await No Atomic object for id: {0}, and ActionIfNoAtomic == Continue", atomicId);
-
-        // is there a Continue target step?
-        final String metaContinueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
-        if (isNotEmpty(metaContinueTargetStepName)) {
-
-            // send row to the Continue output of the step
-            this.putRowTo(data.getOutputRowMeta(), row, data.getContinueOutputRowSet());
-
-            this.logDebug("Await No Atomic, CONTINUE: <{0}>", atomicId);
-            logLineNumber();
-
-        } else {
-            // raise an exception
-            throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.NoContinueTargetStep"));
-        }
-    }
-
-    /**
-     * Send row to the 'Timeout' output target of the step.
-     *
-     * @param meta the Await Step Meta instance
-     * @param data the Await Step Data instance
-     * @param row the row
-     *
-     * @throws KettleException if the timeout target cannot be found, or writing the row causes an error
-     */
-    private void putRowToTimeoutTarget(final AwaitStepMeta meta, final AwaitStepData data, final Object[] row) throws KettleException {
-        // is there a timeout target step?
-        final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
-        if (isNotEmpty(metaTimeoutTargetStepName)) {
-
-            // send row to the timeout output of the step
-            this.putRowTo(data.getOutputRowMeta(), row, data.getTimeoutOutputRowSet());
-
-            logLineNumber();
-
-        } else {
-            // raise an exception
-            throw new KettleException(BaseMessages.getString(PKG, "AwaitStep.Log.NoTimeoutTargetStep"));
-        }
-    }
-
-    /**
-     * Send row to the 'Error' output target of the step.
-     *
-     * @param data the Await Step Data instance
-     * @param row the row
-     * @param errorCode the error code
-     * @param errorMessage a description of the error
-     *
-     * @throws KettleStepException if writing the row causes an error
-     */
-    private void putRowToErrorTarget(final AwaitStepData data, final Object[] row, final ErrorCode errorCode, final String errorMessage) throws KettleStepException {
-        // send row to the error output of the step
-        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), errorCode.getCode());
-        logLineNumber();
-    }
-
-    /**
-     * Send row to the default output target of the step.
-     *
-     * @param data the Await Step Data instance
-     * @param row the row
-     *
-     * @throws KettleStepException if writing the row causes an error
-     */
-    private void putRowToDefaultTarget(final AwaitStepData data, final Object[] row) throws KettleStepException {
-        this.putRow(data.getOutputRowMeta(), row);
-        logLineNumber();
-    }
-
-    /**
-     * Sleeps and then tests if a timeout has been exceeded.
-     *
-     * @param period the period to sleep for
-     * @param timeAlreadyWaited the amount of time previously waited for, e.g. if this function is called more than
-     *                          once in a loop then the result of this function should be added to
-     *                          {@code timeAlreadyWaited} and fed back into this parameter on the next call to it.
-     *                          Can be set to 0 to indicate no previous wait.
-     * @param timeout the timeout to check for, the test is {@code timeout != -1 && (timeAlreadyWaited + period) > timeout}.
-     *                Can be set to -1 to disable any timeout check, in which case 0 will never be returned from this function.
-     *
-     * @return -1 indicates that the (sleeping) Thread was interrupted,
-     *          0 indicates that the timeout was exceeded,
-     *          a non-zero value is the {@code period} waited
-     */
-    private long sleepWithTimeout(final long period, long timeAlreadyWaited, final long timeout) {
-        try {
-            Thread.sleep(period);
-            timeAlreadyWaited += period;
-            if (timeout != -1 && timeAlreadyWaited > timeout) {
-                return 0;
-            }
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt(); // restore interrupted flag
-            return -1;
-        }
-        return period;
-    }
-
-    private void logLineNumber() {
+    @Override
+    protected void logLineNumber() {
         if (checkFeedback(getLinesRead())) {
             if (log.isBasic()) {
                 logBasic(BaseMessages.getString(PKG, "AwaitStep.Log.LineNumber") + getLinesRead());

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStep.java
@@ -157,8 +157,6 @@ public class AwaitStep extends BaseStep implements StepInterface {
         long waited = 0;
         while (true) {
 
-            // refresh the atomic object
-            atomicValue = data.getAtomic(atomicId, atomicType);
 
             if (AtomicType.Boolean == atomicType) {
                 final AtomicBooleanValue atomicBoolean = (AtomicBooleanValue) atomicValue;
@@ -208,6 +206,10 @@ public class AwaitStep extends BaseStep implements StepInterface {
                 logLineNumber();
                 return true; // row done!
             }
+
+            // refresh the atomic object
+            atomicValue = data.getAtomic(atomicId, atomicType);
+
         }  // end while
 
         // send to specific target for Await success

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepData.java
@@ -29,6 +29,7 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicStorage;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicValue;
+import uk.gov.nationalarchives.pdi.step.atomics.OutputMap;
 
 import javax.annotation.Nullable;
 
@@ -39,7 +40,7 @@ public class AwaitStepData extends BaseStepData implements StepDataInterface {
     private String atomicIdFieldName;
     private int atomicIdFieldIndex;
     private RowSet continueOutputRowSet = null;
-    private RowSet atomicValueOutputRowSet = null;
+    private final OutputMap atomicValueOutputRowSets = new OutputMap();
     private RowSet timeoutOutputRowSet = null;
 
     public AwaitStepData() {
@@ -92,12 +93,8 @@ public class AwaitStepData extends BaseStepData implements StepDataInterface {
         this.continueOutputRowSet = continueOutputRowSet;
     }
 
-    public RowSet getAtomicValueOutputRowSet() {
-        return atomicValueOutputRowSet;
-    }
-
-    public void setAtomicValueOutputRowSet(final RowSet atomicValueOutputRowSet) {
-        this.atomicValueOutputRowSet = atomicValueOutputRowSet;
+    public OutputMap getAtomicValueOutputRowSets() {
+        return atomicValueOutputRowSets;
     }
 
     public RowSet getTimeoutOutputRowSet() {

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepData.java
@@ -22,88 +22,12 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics.await;
 
-import org.pentaho.di.core.RowSet;
-import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.trans.step.BaseStepData;
-import org.pentaho.di.trans.step.StepDataInterface;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicStorage;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicValue;
-import uk.gov.nationalarchives.pdi.step.atomics.OutputMap;
-
-import javax.annotation.Nullable;
+import uk.gov.nationalarchives.pdi.step.atomics.AbstractAtomicStepData;
 
 
-public class AwaitStepData extends BaseStepData implements StepDataInterface {
-
-    private RowMetaInterface outputRowMeta;
-    private String atomicIdFieldName;
-    private int atomicIdFieldIndex;
-    private RowSet continueOutputRowSet = null;
-    private final OutputMap atomicValueOutputRowSets = new OutputMap();
-    private RowSet timeoutOutputRowSet = null;
+public class AwaitStepData extends AbstractAtomicStepData {
 
     public AwaitStepData() {
         super();
     }
-
-    public @Nullable
-    AtomicValue getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
-        return AtomicStorage.INSTANCE.getAtomic(id, atomicType);
-    }
-
-    public AtomicValue getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
-        return AtomicStorage.INSTANCE.getOrCreateAtomic(id, atomicType, initialValue);
-    }
-
-    public boolean removeAtomic(final String id) {
-        return AtomicStorage.INSTANCE.removeAtomic(id);
-    }
-
-    // <editor-fold desc="get/set properties">
-    public RowMetaInterface getOutputRowMeta() {
-        return outputRowMeta;
-    }
-
-    public void setOutputRowMeta(final RowMetaInterface outputRowMeta) {
-        this.outputRowMeta = outputRowMeta;
-    }
-
-    public String getAtomicIdFieldName() {
-        return atomicIdFieldName;
-    }
-
-    public void setAtomicIdFieldName(final String atomicIdFieldName) {
-        this.atomicIdFieldName = atomicIdFieldName;
-    }
-
-    public int getAtomicIdFieldIndex() {
-        return atomicIdFieldIndex;
-    }
-
-    public void setAtomicIdFieldIndex(final int atomicIdFieldIndex) {
-        this.atomicIdFieldIndex = atomicIdFieldIndex;
-    }
-
-    public RowSet getContinueOutputRowSet() {
-        return continueOutputRowSet;
-    }
-
-    public void setContinueOutputRowSet(final RowSet continueOutputRowSet) {
-        this.continueOutputRowSet = continueOutputRowSet;
-    }
-
-    public OutputMap getAtomicValueOutputRowSets() {
-        return atomicValueOutputRowSets;
-    }
-
-    public RowSet getTimeoutOutputRowSet() {
-        return timeoutOutputRowSet;
-    }
-
-    public void setTimeoutOutputRowSet(final RowSet timeoutOutputRowSet) {
-        this.timeoutOutputRowSet = timeoutOutputRowSet;
-    }
-
-    // </editor-fold>
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepMeta.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitStepMeta.java
@@ -43,6 +43,7 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import uk.gov.nationalarchives.pdi.step.atomics.AbstractAtomicStepMeta;
 import uk.gov.nationalarchives.pdi.step.atomics.ActionIfNoAtomic;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
 
@@ -54,58 +55,30 @@ import static uk.gov.nationalarchives.pdi.step.atomics.Util.*;
 
 @Step(id = "AwaitStep", image = "AwaitStep.svg", name = "Await Atomic Value",
         description = "Waits for an Atomic Value to be Set", categoryDescription = "Flow")
-public class AwaitStepMeta extends BaseStepMeta implements StepMetaInterface {
+public class AwaitStepMeta extends AbstractAtomicStepMeta {
 
     private static Class<?> PKG = AwaitStep.class; // for i18n purposes, needed by Translator2!!   $NON-NLS-1$
 
     // <editor-fold desc="settings XML element names">
-    private static final String ELEM_NAME_ATOMIC_ID_FIELD_NAME = "atomicIdFieldName";
-    private static final String ELEM_NAME_ATOMIC_TYPE = "atomicType";
-    private static final String ELEM_NAME_ACTION_IF_NO_ATOMIC = "actionIfNoAtomic";
-    private static final String ATTR_NAME_CONTINUE_TARGET_STEP = "continueTargetStep";
-    private static final String ATTR_NAME_VALUE = "value";
-    private static final String ELEM_NAME_ATOMIC_VALUES = "atomicValues";
-    private static final String ELEM_NAME_ATOMIC_VALUE = "atomicValue";
     private static final String ATTR_NAME_AWAIT = "await";
     private static final String ATTR_NAME_DISCARD_ATOMIC = "discardAtomic";
-    private static final String ATTR_NAME_TARGET_STEP = "targetStep";
     private static final String ELEM_NAME_WAIT_LOOP = "waitLoop";
-    private static final String ATTR_NAME_CHECK_PERIOD = "checkPeriod";
-    private static final String ATTR_NAME_TIMEOUT = "timeout";
-    private static final String ATTR_NAME_TIMEOUT_TARGET_STEP = "timeoutTargetStep";
-    // </editor-fold>
 
-    private static final long DEFAULT_CHECK_PERIOD = 100; // ms
-    private static final long TIMEOUT_DISABLED = -1; // No timeout
-    private static final long DEFAULT_TIMEOUT = TIMEOUT_DISABLED;
+    // </editor-fold>
 
     private static final Stream NEW_CONTINUE_STREAM = new Stream(StreamInterface.StreamType.TARGET, (StepMeta)null, BaseMessages.getString(PKG, "AwaitStepMeta.TargetStream.Continue.Description", new String[0]), StreamIcon.TARGET, (Object)null);
     private static final Stream NEW_ATOMIC_VALUE_STREAM = new Stream(StreamInterface.StreamType.TARGET, (StepMeta)null, BaseMessages.getString(PKG, "AwaitStepMeta.TargetStream.AtomicValue.Description", new String[0]), StreamIcon.OUTPUT, (Object)null);
     private static final Stream NEW_TIMEOUT_STREAM = new Stream(StreamInterface.StreamType.TARGET, (StepMeta)null, BaseMessages.getString(PKG, "AwaitStepMeta.TargetStream.Timeout.Description", new String[0]), StreamIcon.FALSE, (Object)null);
 
     // <editor-fold desc="settings">
-    private String atomicIdFieldName;
-    private AtomicType atomicType;
-    private ActionIfNoAtomic actionIfNoAtomic;
-    private String continueTargetStepname;
-    @Nullable private String initialiseAtomicValue;
-    private long waitAtomicCheckPeriod = DEFAULT_CHECK_PERIOD;
-    private long waitAtomicTimeout = DEFAULT_TIMEOUT;
     @Nullable private List<AwaitTarget> awaitValues;
     private long waitLoopCheckPeriod = DEFAULT_CHECK_PERIOD;
     private long waitLoopTimeout = DEFAULT_TIMEOUT;
-    private String timeoutTargetStepname;
     // </editor-fold>
-
-    @Nullable private StepMeta continueTargetStep;
-    @Nullable private StepMeta timeoutTargetStep;
 
     @Override
     public void setDefault() {
-        atomicIdFieldName = "";
-        atomicType = AtomicType.Boolean;
-        actionIfNoAtomic = ActionIfNoAtomic.Continue;
-        initialiseAtomicValue = null;
+        super.setDefault();
         awaitValues = new ArrayList<>();
         waitLoopCheckPeriod = DEFAULT_CHECK_PERIOD;
         waitLoopTimeout = DEFAULT_TIMEOUT;
@@ -445,70 +418,6 @@ public class AwaitStepMeta extends BaseStepMeta implements StepMetaInterface {
     }
 
     // <editor-fold desc="settings getters and setters">
-    public String getAtomicIdFieldName() {
-        return atomicIdFieldName;
-    }
-
-    public void setAtomicIdFieldName(final String atomicIdFieldName) {
-        this.atomicIdFieldName = atomicIdFieldName;
-    }
-
-    public AtomicType getAtomicType() {
-        return atomicType;
-    }
-
-    public void setAtomicType(final AtomicType atomicType) {
-        this.atomicType = atomicType;
-    }
-
-    public ActionIfNoAtomic getActionIfNoAtomic() {
-        return actionIfNoAtomic;
-    }
-
-    public void setActionIfNoAtomic(final ActionIfNoAtomic actionIfNoAtomic) {
-        this.actionIfNoAtomic = actionIfNoAtomic;
-    }
-
-    public String getContinueTargetStepname() {
-        return continueTargetStepname;
-    }
-
-    public void setContinueTargetStepname(final String continueTargetStepname) {
-        this.continueTargetStepname = continueTargetStepname;
-    }
-
-    @Nullable public StepMeta getContinueTargetStep() {
-        return continueTargetStep;
-    }
-
-    public void setContinueTargetStep(@Nullable final StepMeta continueTargetStep) {
-        this.continueTargetStep = continueTargetStep;
-    }
-
-    public @Nullable String getInitialiseAtomicValue() {
-        return initialiseAtomicValue;
-    }
-
-    public void setInitialiseAtomicValue(@Nullable final String initialiseAtomicValue) {
-        this.initialiseAtomicValue = initialiseAtomicValue;
-    }
-
-    public long getWaitAtomicCheckPeriod() {
-        return waitAtomicCheckPeriod;
-    }
-
-    public void setWaitAtomicCheckPeriod(final long waitAtomicCheckPeriod) {
-        this.waitAtomicCheckPeriod = waitAtomicCheckPeriod;
-    }
-
-    public long getWaitAtomicTimeout() {
-        return waitAtomicTimeout;
-    }
-
-    public void setWaitAtomicTimeout(final long waitAtomicTimeout) {
-        this.waitAtomicTimeout = waitAtomicTimeout;
-    }
-
     public @Nullable List<AwaitTarget> getAwaitValues() {
         return awaitValues;
     }
@@ -532,22 +441,5 @@ public class AwaitStepMeta extends BaseStepMeta implements StepMetaInterface {
     public void setWaitLoopTimeout(final long waitLoopTimeout) {
         this.waitLoopTimeout = waitLoopTimeout;
     }
-
-    public String getTimeoutTargetStepname() {
-        return timeoutTargetStepname;
-    }
-
-    public void setTimeoutTargetStepname(final String timeoutTargetStepname) {
-        this.timeoutTargetStepname = timeoutTargetStepname;
-    }
-
-    public StepMeta getTimeoutTargetStep() {
-        return timeoutTargetStep;
-    }
-
-    public void setTimeoutTargetStep(final StepMeta timeoutTargetStep) {
-        this.timeoutTargetStep = timeoutTargetStep;
-    }
-
     // </editor-fold>
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitTarget.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitTarget.java
@@ -25,6 +25,7 @@ package uk.gov.nationalarchives.pdi.step.atomics.await;
 import org.pentaho.di.trans.step.StepMeta;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 public class AwaitTarget implements Cloneable {
 
@@ -87,5 +88,23 @@ public class AwaitTarget implements Cloneable {
     @Override
     public String toString() {
         return "[==" + (atomicValue != null ? atomicValue : "null") + "] => " + (targetStep != null ? targetStep.getName() : targetStepname);
+    }
+
+    /**
+     * Searches the {@code awaitTargets} and returns the first AwaitTarget
+     * which has a null AtomicValue.
+     *
+     * @param awaitTargets the AwaitTargets to search
+     *
+     * @return the first AwaitTarget which has a null AtomicValue,
+     *         else if there is no such AwaitTarget then null is returned.
+     */
+    public static @Nullable AwaitTarget findAwaitTargetForNullValue(final List<AwaitTarget> awaitTargets) {
+        for (final AwaitTarget awaitTarget : awaitTargets) {
+            if (awaitTarget.getAtomicValue() == null) {
+                return awaitTarget;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitTarget.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitTarget.java
@@ -1,0 +1,91 @@
+/**
+ * The MIT License
+ * Copyright © 2021 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package uk.gov.nationalarchives.pdi.step.atomics.await;
+
+import org.pentaho.di.trans.step.StepMeta;
+
+import javax.annotation.Nullable;
+
+public class AwaitTarget implements Cloneable {
+
+    @Nullable private String atomicValue;
+    private boolean discardAtomic;
+    private String targetStepname;
+
+    @Nullable
+    private StepMeta targetStep;
+
+    public AwaitTarget(@Nullable final String atomicValue, final boolean discardAtomic, final String targetStepname) {
+        this.atomicValue = atomicValue;
+        this.discardAtomic = discardAtomic;
+        this.targetStepname = targetStepname;
+    }
+
+    public AwaitTarget(@Nullable final String atomicValue, final boolean discardAtomic, @Nullable final StepMeta targetStep) {
+        this.atomicValue = atomicValue;
+        this.discardAtomic = discardAtomic;
+        this.targetStep = targetStep;
+    }
+
+    @Nullable public String getAtomicValue() {
+        return atomicValue;
+    }
+
+    public void setAtomicValue(@Nullable final String atomicValue) {
+        this.atomicValue = atomicValue;
+    }
+
+    public boolean isDiscardAtomic() {
+        return discardAtomic;
+    }
+
+    public void setDiscardAtomic(final boolean discardAtomic) {
+        this.discardAtomic = discardAtomic;
+    }
+
+    public String getTargetStepname() {
+        return targetStepname;
+    }
+
+    public void setTargetStepname(final String targetStepname) {
+        this.targetStepname = targetStepname;
+    }
+
+    @Nullable public StepMeta getTargetStep() {
+        return targetStep;
+    }
+
+    public void setTargetStep(@Nullable final StepMeta targetStep) {
+        this.targetStep = targetStep;
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        return super.clone();
+    }
+
+    @Override
+    public String toString() {
+        return "[==" + (atomicValue != null ? atomicValue : "null") + "] => " + (targetStep != null ? targetStep.getName() : targetStepname);
+    }
+}

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
@@ -164,9 +164,6 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             long waitedForSet = 0;
             while (true) {
 
-                // refresh the atomic object
-                atomicValue = data.getAtomic(atomicId, atomicType);
-
                 set = false;
 
                 // try and set each value in turn
@@ -266,6 +263,10 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                 } else {
                     throw new IllegalArgumentException("CAS Unknown ActionIfUnableToSet: " + actionIfUnableToSet.name());
                 }
+
+                // refresh the atomic object
+                atomicValue = data.getAtomic(atomicId, atomicType);
+
             }  // end while
         }
 

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
@@ -97,7 +97,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             }
 
 
-            // when atomicObj null...
+            // when atomicValue null...
 
             if (ActionIfNoAtomic.Continue == actionIfNoAtomic) {
                 // send row to the 'Continue' output of the step
@@ -151,7 +151,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             }
         }  // end while
 
-        // At this point we have an atomicObj
+        // At this point we have an atomicValue
         final ActionIfUnableToSet actionIfUnableToSet = meta.getActionIfUnableToSet();
         CompareAndSetTarget casTarget = null;
 
@@ -266,7 +266,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                 } else {
                     throw new IllegalArgumentException("CAS Unknown ActionIfUnableToSet: " + actionIfUnableToSet.name());
                 }
-            }
+            }  // end while
         }
 
         if (casTarget != null) {

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
@@ -272,7 +272,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
 
         if (casTarget != null) {
             // send to specific target for CAS success
-            final Set<RowSet> casTargetRowSets = data.getCasOutputRowSets().get(casTarget.getCompareValue());
+            final Set<RowSet> casTargetRowSets = data.getOutputRowSets().get(casTarget.getCompareValue());
             if (casTargetRowSets == null || casTargetRowSets.isEmpty()) {
                 throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTargetRowSetForStep", new Object[] { casTarget.getTargetStep() != null ? casTarget.getTargetStep().getName() : casTarget.getTargetStepname() }));
             }
@@ -370,7 +370,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                 }
 
                 // store the compare value and the rowset
-                data.getCasOutputRowSets().put(compareAndSetValue.getCompareValue(), rowSet);
+                data.getOutputRowSets().put(compareAndSetValue.getCompareValue(), rowSet);
             }
 
 

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
@@ -22,6 +22,7 @@
  */
 package uk.gov.nationalarchives.pdi.step.atomics.compareandset;
 
+import com.evolvedbinary.j8fu.Either;
 import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.exception.KettleException;
 import org.pentaho.di.core.row.RowMetaInterface;
@@ -36,10 +37,20 @@ import uk.gov.nationalarchives.pdi.step.atomics.*;
 import java.util.List;
 import java.util.Set;
 
+import static com.evolvedbinary.j8fu.Either.Left;
+import static com.evolvedbinary.j8fu.Either.Right;
 import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNotEmpty;
 import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNullOrEmpty;
 
-public class CompareAndSetStep extends BaseStep implements StepInterface {
+public class CompareAndSetStep extends AbstractAtomicStep {
+
+    private enum CASAtomicRouteTarget {
+        DEFAULT,
+        SKIP,
+        ERROR,
+        TIMEOUT,
+        THREAD_INTERRUPTED
+    }
 
     private static Class<?> PKG = CompareAndSetStep.class; // for i18n purposes, needed by Translator2!!   $NON-NLS-1$
 
@@ -50,7 +61,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
 
     @Override
     public boolean processRow(final StepMetaInterface smi, final StepDataInterface sdi) throws KettleException {
-        Object[] row = getRow(); // try and get a row
+        final Object[] row = getRow(); // try and get a row
         if (row == null) {
             // no more rows...
             setOutputDone();
@@ -68,103 +79,110 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             createOutputValueMapping(meta, data);
         }
 
-        final Object atomicIdFieldNameValue = row[data.getAtomicIdFieldIndex()];
+        final String atomicId = getAtomicId(data, row);
 
-        final String atomicId;
-        if (atomicIdFieldNameValue instanceof String) {
-            atomicId = (String) atomicIdFieldNameValue;
-        } else {
-            throw new KettleException("Expected field " + data.getAtomicIdFieldName() + " to contain a String, but found "
-                    + atomicIdFieldNameValue.getClass());
+        // 1. get (or initialise) the AtomicValue
+        final Either<GetAtomicRouteTarget, AtomicValue> routeOrAtomic = getAtomic(meta, data, atomicId);
+        if (routeOrAtomic.isLeft()) {
+            // could not get (or initialise) AtomicValue, so route row to specific output target...
+            final GetAtomicRouteTarget route = routeOrAtomic.left().get();
+            switch (route) {
+                case CONTINUE:
+                    putRowToContinueTarget(meta, data, atomicId, row, BaseMessages.getString(PKG, "CompareAndSetStep.Log.NoContinueTargetStep"));
+                    return true;
+
+                case ERROR:
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC, "CAS No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error");
+                    return true;
+
+                case TIMEOUT:
+                    // NOTE: this is intentionally sent to the error target at this stage, the timeout target is reserved for the await value part further below
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT, "CAS Timeout (" + meta.getWaitAtomicTimeout() + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
+                    return true;
+
+                case THREAD_INTERRUPTED:
+                    putRowToErrorTarget(data, row, ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED, "CAS Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait");
+                    return true;
+            }
         }
 
-        final ActionIfNoAtomic actionIfNoAtomic = meta.getActionIfNoAtomic();
+        // At this point we have an AtomicValue
+        final AtomicValue atomicValue = routeOrAtomic.right().get();
+
+        // 2. Check/Wait until the AtomicValue reaches one of the await values, and then get the target
+        final Either<CASAtomicRouteTarget, CompareAndSetTarget> routeOrCasTarget = casAndGetTarget(meta, data, atomicId, atomicValue);
+        if (routeOrCasTarget.isLeft()) {
+            // AtomicValue never completed CAS, so route row to specific failure output target...
+            final CASAtomicRouteTarget route = routeOrCasTarget.left().get();
+            switch (route) {
+                case DEFAULT:
+                    putRowToDefaultTarget(data, row);
+                    return true;
+
+                case SKIP:
+                    putRowToSkipTarget(meta, data, atomicId, row);
+                    return true;
+
+                case ERROR:
+                    putRowToErrorTarget(data, row, ErrorCode.CAS_FAILED, "Unable to Compare And Set Value for: " + atomicId + ", and ActionIfUnableToSet == Error");
+                    return true;
+
+                case TIMEOUT:
+                    putRowToTimeoutTarget(meta, data, row, BaseMessages.getString(PKG, "CompareAndSetStep.Log.NoTimeoutTargetStep"));
+                    return true;
+
+                case THREAD_INTERRUPTED:
+                    putRowToErrorTarget(data, row, ErrorCode.CAS_ATOMIC_WAIT_INTERRUPTED, "Thread interrupted whilst waiting to CAS Atomic value for id: " + atomicId);
+                    return true;
+            }
+        }
+
+        // At this point we have a CompareAndSetTarget, i.e. the AtomicValue completed CAS
+        final CompareAndSetTarget casTarget = routeOrCasTarget.right().get();
+
+        // We now send the input row to specific targets for CAS success
+        final Set<RowSet> casTargetRowSets = data.getOutputRowSets().get(casTarget.getCompareValue());
+        if (casTargetRowSets == null || casTargetRowSets.isEmpty()) {
+            throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTargetRowSetForStep", new Object[] { casTarget.getTargetStep() != null ? casTarget.getTargetStep().getName() : casTarget.getTargetStepname() }));
+        }
+
+        // send the row to the success targets
+        for (final RowSet casTargetRowSet : casTargetRowSets) {
+            this.putRowTo(data.getOutputRowMeta(), row, casTargetRowSet);
+        }
+
+        this.logDebug("CAS OK: <{0}>{1}", atomicId, casTarget.toString());
+
+        logLineNumber();
+
+        return true;  // row done!
+    }
+
+    /**
+     * Attempts to CAS the AtomicValue.
+     *
+     * This method internally will loop approximately every {@link CompareAndSetStepMeta#getUnableToSetLoopCheckPeriod()} ()}
+     * until the AtomicValue matches one of the await values, or {@link CompareAndSetStepMeta#getUnableToSetLoopTimeout()} is reached.
+     *
+     * @param meta the ComapreAndSet Step Meta instance
+     * @param data the ComapreAndSet Step Data instance
+     * @param atomicId the id of the AtomicValue
+     * @param atomicValue the AtomicValue on which we try to CAS
+     *
+     * @return Either a route to target if the AtomicValue cannot be CAS'd,
+     *    or the CompareAndSetTarget to route the output to when it has been CAS'd.
+     */
+    private Either<CASAtomicRouteTarget, CompareAndSetTarget> casAndGetTarget(final CompareAndSetStepMeta meta, final CompareAndSetStepData data, final String atomicId, AtomicValue atomicValue) {
         final AtomicType atomicType = meta.getAtomicType();
-        final long waitAtomicCheckPeriod = meta.getWaitAtomicCheckPeriod();
-        final long waitAtomicTimeout = meta.getWaitAtomicTimeout();
-
-        long waitedForAtomic = 0;
-        AtomicValue atomicValue = null;
-        while (true) {
-            if (ActionIfNoAtomic.Initialise == actionIfNoAtomic) {
-                atomicValue = data.getOrCreateAtomic(atomicId, atomicType, meta.getInitialiseAtomicValue());
-            } else {
-                atomicValue = data.getAtomic(atomicId, atomicType);
-            }
-
-            if (atomicValue != null) {
-                break;  // exit while loop
-            }
-
-
-            // when atomicValue null...
-
-            if (ActionIfNoAtomic.Continue == actionIfNoAtomic) {
-                // send row to the 'Continue' output of the step
-                this.logDebug("CAS No Atomic object for id: {0}, and ActionIfNoAtomic == Continue", atomicId);
-
-                // is there a Continue target step?
-                final String continueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
-                if (isNotEmpty(continueTargetStepName)) {
-
-                    // send row to the Continue output of the step
-                    this.putRowTo(data.getOutputRowMeta(), row, data.getContinueOutputRowSet());
-
-                    this.logDebug("CAS No Atomic, CONTINUE: <{0}>", atomicId);
-                    logLineNumber();
-
-                    return true; // row done!
-
-                } else {
-                    // raise an exception
-                    throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.NoContinueTargetStep"));
-                }
-
-
-            } else if (ActionIfNoAtomic.Error == actionIfNoAtomic) {
-                // send row to the error output of the step
-                final String errorMessage = "CAS No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error";
-                this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC.getCode());
-                logLineNumber();
-                return true; // row done!
-
-            } else if (ActionIfNoAtomic.Wait == actionIfNoAtomic) {
-                try {
-                    Thread.sleep(waitAtomicCheckPeriod);
-                    waitedForAtomic += waitAtomicCheckPeriod;
-                    if (waitAtomicTimeout != -1 && waitedForAtomic > waitAtomicTimeout) {
-                        // TIMEOUT reached!
-                        // send row to the error output of the step
-                        final String errorMessage = "CAS Timeout (" + waitAtomicTimeout + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait";
-                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT.getCode());
-                        logLineNumber();
-                        return true; // row done!
-                    }
-                } catch (final InterruptedException e) {
-                    Thread.currentThread().interrupt(); // restore interrupted flag
-                    // send row to the error output of the step
-                    final String errorMessage = "CAS Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait";
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED.getCode());
-                    logLineNumber();
-                    return true; // row done!
-                }
-            }
-        }  // end while
-
-        // At this point we have an atomicValue
         final ActionIfUnableToSet actionIfUnableToSet = meta.getActionIfUnableToSet();
-        CompareAndSetTarget casTarget = null;
-
         final List<CompareAndSetTarget> compareAndSetValues = meta.getCompareAndSetValues();
         if (compareAndSetValues != null && !compareAndSetValues.isEmpty()) {
+
             final long unableToSetLoopCheckPeriod = meta.getUnableToSetLoopCheckPeriod();
-            final long unableToSetTimeoutPeriod = meta.getUnableToSetLoopTimeout();
+            final long unableToSetTimeout = meta.getUnableToSetLoopTimeout();
 
-            boolean set = false;
-            long waitedForSet = 0;
+            long waited = 0;
             while (true) {
-
-                set = false;
 
                 // try and set each value in turn
                 for (final CompareAndSetTarget compareAndSetValue : compareAndSetValues) {
@@ -173,91 +191,47 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                         final AtomicBooleanValue atomicBoolean = (AtomicBooleanValue) atomicValue;
                         final boolean compareValue = Boolean.valueOf(compareAndSetValue.getCompareValue());
                         final boolean setValue = Boolean.valueOf(compareAndSetValue.getSetValue());
-                        set = atomicBoolean.compareAndSet(compareValue, setValue);
+                        if (atomicBoolean.compareAndSet(compareValue, setValue)) {
+                            return Right(compareAndSetValue);
+                        }
 
                     } else if (AtomicType.Integer == atomicType) {
                         final AtomicIntegerValue atomicInteger = (AtomicIntegerValue) atomicValue;
                         final int compareValue = Integer.valueOf(compareAndSetValue.getCompareValue());
                         final int setValue = Integer.valueOf(compareAndSetValue.getSetValue());
-                        set = atomicInteger.compareAndSet(compareValue, setValue);
+                        if (atomicInteger.compareAndSet(compareValue, setValue)) {
+                            return Right(compareAndSetValue);
+                        }
 
                     } else {
                         throw new IllegalArgumentException("Unknown AtomicType: " + atomicType.name());
                     }
-
-                    if (set) {
-                        casTarget = compareAndSetValue;
-                        break; // CaS succeeded, exit for loop
-                    }
                 }  // end for
 
-                if (set) {
-                    break; // CaS succeeded, exit while loop
-                }
-
                 if (ActionIfUnableToSet.Skip == actionIfUnableToSet) {
-
-                    // send row to the 'Skip' output of the step
-//                        this.logDebug("CAS Unable to set: <{0}>, and ActionIfUnableToSet == Skip", atomicId);
-
-                    // is there a Skip target step?
-                    final String metaSkipTargetStepName = meta.getSkipTargetStep() != null ? meta.getSkipTargetStep().getName() : meta.getSkipTargetStepname();
-                    if (isNotEmpty(metaSkipTargetStepName)) {
-
-                        // send row to the Skip output of the step
-                        this.putRowTo(data.getOutputRowMeta(), row, data.getSkipOutputRowSet());
-
-                        this.logDebug("CAS SKIP: <{0}>",atomicId);
-                        logLineNumber();
-
-                        return true; // row done!
-
-                    } else {
-                        // raise an exception
-                        throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.NoSkipTargetStep"));
-                    }
-
+                    return Left(CASAtomicRouteTarget.SKIP);
 
                 } else if (ActionIfUnableToSet.Error == actionIfUnableToSet) {
                     // send row to the error output of the step
-                    final String errorMessage = "Unable to Compare And Set Value for: " + atomicId + ", and ActionIfUnableToSet == Error";
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.CAS_FAILED.getCode());
-                    logLineNumber();
-                    return true; // row done!
+                    return Left(CASAtomicRouteTarget.ERROR);
 
                 } else if (ActionIfUnableToSet.Loop == actionIfUnableToSet) {
 
                     // wait before loop to reattempt CaS
-                    try {
-                        Thread.sleep(unableToSetLoopCheckPeriod);
-                        waitedForSet += unableToSetLoopCheckPeriod;
-                        if (unableToSetTimeoutPeriod != -1 && waitedForSet > unableToSetTimeoutPeriod) {
-                            // TIMEOUT reached!
+                    final long sleptFor = sleepWithTimeout(unableToSetLoopCheckPeriod, waited, unableToSetTimeout);
 
-                            // is there a timeout target step?
-                            final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
-                            if (isNotEmpty(metaTimeoutTargetStepName)) {
+                    if (sleptFor > 0) {
+                        // slept OK
+                        waited += sleptFor;
+                        // loop to try and match the atomic value again
 
-                                // send row to the timeout output of the step
-                                this.putRowTo(data.getOutputRowMeta(), row, data.getTimeoutOutputRowSet());
+                    }  else if (sleptFor == 0) {
+                        // TIMEOUT reached after sleeping
+                        return Left(CASAtomicRouteTarget.TIMEOUT);
 
-                                this.logDebug("CAS TIMEOUT: <{0}>", atomicId);
-                                logLineNumber();
-
-                                return true; // row done!
-
-                            } else {
-                                // raise an exception
-                                throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.NoTimeoutTargetStep"));
-                            }
-                        }
-                    } catch (final InterruptedException e) {
-                        Thread.currentThread().interrupt(); // restore interrupted flag
-                        // send row to the error output of the step
-                        final String errorMessage = "Thread interrupted whilst waiting to CAS Atomic value for id: " + atomicId;
-                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.CAS_ATOMIC_WAIT_INTERRUPTED.getCode());
-                        logLineNumber();
-                        return true; // row done!
+                    } else {
+                        // Thread INTERRUPTED whilst sleeping
+                        return Left(CASAtomicRouteTarget.THREAD_INTERRUPTED);
                     }
 
                 } else {
@@ -270,30 +244,38 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             }  // end while
         }
 
-        if (casTarget != null) {
-            // send to specific target for CAS success
-            final Set<RowSet> casTargetRowSets = data.getOutputRowSets().get(casTarget.getCompareValue());
-            if (casTargetRowSets == null || casTargetRowSets.isEmpty()) {
-                throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTargetRowSetForStep", new Object[] { casTarget.getTargetStep() != null ? casTarget.getTargetStep().getName() : casTarget.getTargetStepname() }));
-            }
-
-            for (final RowSet casTargetRowSet : casTargetRowSets) {
-                this.putRowTo(data.getOutputRowMeta(), row, casTargetRowSet);
-            }
-
-            this.logDebug("CAS OK: <{0}>{1}", atomicId, casTarget.toString());
-
-        } else {
-            //send to default output if no CAS Target
-            this.putRow(data.getOutputRowMeta(), row);
-        }
-
-        logLineNumber();
-
-        return true;  // row done!
+        // send to default output if no CAS Target
+        return Left(CASAtomicRouteTarget.DEFAULT);
     }
 
-    private void logLineNumber() {
+    /**
+     * Send row to the 'Skip' output target of the step.
+     *
+     * @param meta the Step Meta instance
+     * @param data the Step Data instance
+     * @param atomicId the id of the AtomicValue
+     * @param row the row
+     *
+     * @throws KettleException if the continue target cannot be found, or writing the row causes an error
+     */
+    protected void putRowToSkipTarget(final CompareAndSetStepMeta meta, final CompareAndSetStepData data, final String atomicId, final Object[] row) throws KettleException {
+        // is there a Skip target step?
+        final String metaSkipTargetStepName = meta.getSkipTargetStep() != null ? meta.getSkipTargetStep().getName() : meta.getSkipTargetStepname();
+        if (isNotEmpty(metaSkipTargetStepName)) {
+
+            // send row to the Skip output of the step
+            this.putRowTo(data.getOutputRowMeta(), row, data.getSkipOutputRowSet());
+            this.logDebug("CAS SKIP: <{0}>",atomicId);
+            logLineNumber();
+
+        } else {
+            // raise an exception
+            throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.NoSkipTargetStep"));
+        }
+    }
+
+    @Override
+    protected void logLineNumber() {
         if (checkFeedback(getLinesRead())) {
             if (log.isBasic()) {
                 logBasic(BaseMessages.getString(PKG, "CompareAndSetStep.Log.LineNumber") + getLinesRead());
@@ -341,72 +323,68 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             throw new KettleException(BaseMessages.getString( PKG, "CompareAndSetStep.Exception.UnableToFindFieldName", atomicIdFieldName));
         }
 
-//        try {
-            final StepIOMetaInterface ioMeta = meta.getStepIOMeta();
+        final StepIOMetaInterface ioMeta = meta.getStepIOMeta();
 
-            // There is one or many CAS target for each target stream.
+        // There is one or many CAS target for each target stream.
 
-            final List<StreamInterface> targetStreams = ioMeta.getTargetStreams();
-            for (int i = 0; i < targetStreams.size(); i++) {
-                final Object subject = targetStreams.get(i).getSubject();
-                if (subject == null) {
-                    continue;  // Skip over default option
-                }
-                if (!(subject instanceof CompareAndSetTarget)) {
-                    continue;  // Skip over other target type
-                }
-
-                final CompareAndSetTarget compareAndSetValue = (CompareAndSetTarget) subject;
-
-                final String casTargetStepName = compareAndSetValue.getTargetStep() != null ? compareAndSetValue.getTargetStep().getName() : compareAndSetValue.getTargetStepname();
-                if (isNullOrEmpty(casTargetStepName)) {
-                    throw new KettleException(BaseMessages.getString(
-                            PKG, "CompareAndSetStep.Log.NoTargetStepSpecifiedForValue", compareAndSetValue.getCompareValue(), compareAndSetValue.getSetValue()));
-                }
-
-                final RowSet rowSet = findOutputRowSet(casTargetStepName);
-                if (rowSet == null) {
-                    throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTargetRowSetForStep", new Object[] { casTargetStepName }));
-                }
-
-                // store the compare value and the rowset
-                data.getOutputRowSets().put(compareAndSetValue.getCompareValue(), rowSet);
+        final List<StreamInterface> targetStreams = ioMeta.getTargetStreams();
+        for (int i = 0; i < targetStreams.size(); i++) {
+            final Object subject = targetStreams.get(i).getSubject();
+            if (subject == null) {
+                continue;  // Skip over default option
+            }
+            if (!(subject instanceof CompareAndSetTarget)) {
+                continue;  // Skip over other target type
             }
 
+            final CompareAndSetTarget compareAndSetValue = (CompareAndSetTarget) subject;
 
-            // The ioMeta object also has optional target streams for: continue, skip, and timeout.
-
-            final String metaContinueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
-            if (isNotEmpty(metaContinueTargetStepName)) {
-                final RowSet rowSet = findOutputRowSet(metaContinueTargetStepName);
-                if (rowSet != null) {
-                    data.setContinueOutputRowSet(rowSet);
-                } else {
-                    throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindContinueTargetRowSetForStep", new Object[]{ metaContinueTargetStepName }));
-                }
+            final String casTargetStepName = compareAndSetValue.getTargetStep() != null ? compareAndSetValue.getTargetStep().getName() : compareAndSetValue.getTargetStepname();
+            if (isNullOrEmpty(casTargetStepName)) {
+                throw new KettleException(BaseMessages.getString(
+                        PKG, "CompareAndSetStep.Log.NoTargetStepSpecifiedForValue", compareAndSetValue.getCompareValue(), compareAndSetValue.getSetValue()));
             }
 
-            final String metaSkipTargetStepName = meta.getSkipTargetStep() != null ? meta.getSkipTargetStep().getName() : meta.getSkipTargetStepname();
-            if (isNotEmpty(metaSkipTargetStepName)) {
-                final RowSet rowSet = findOutputRowSet(metaSkipTargetStepName);
-                if (rowSet != null) {
-                    data.setSkipOutputRowSet(rowSet);
-                } else {
-                    throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindSkipTargetRowSetForStep", new Object[]{ metaSkipTargetStepName }));
-                }
+            final RowSet rowSet = findOutputRowSet(casTargetStepName);
+            if (rowSet == null) {
+                throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTargetRowSetForStep", new Object[] { casTargetStepName }));
             }
 
-            final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
-            if (isNotEmpty(metaTimeoutTargetStepName)) {
-                final RowSet rowSet = findOutputRowSet(metaTimeoutTargetStepName);
-                if (rowSet != null) {
-                    data.setTimeoutOutputRowSet(rowSet);
-                } else {
-                    throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTimeoutTargetRowSetForStep", new Object[] { metaTimeoutTargetStepName }));
-                }
+            // store the compare value and the rowset
+            data.getOutputRowSets().put(compareAndSetValue.getCompareValue(), rowSet);
+        }
+
+
+        // The ioMeta object also has optional target streams for: continue, skip, and timeout.
+
+        final String metaContinueTargetStepName = meta.getContinueTargetStep() != null ? meta.getContinueTargetStep().getName() : meta.getContinueTargetStepname();
+        if (isNotEmpty(metaContinueTargetStepName)) {
+            final RowSet rowSet = findOutputRowSet(metaContinueTargetStepName);
+            if (rowSet != null) {
+                data.setContinueOutputRowSet(rowSet);
+            } else {
+                throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindContinueTargetRowSetForStep", new Object[]{ metaContinueTargetStepName }));
             }
-//        } catch (final Exception e) {
-//            throw new KettleException(e);
-//        }
+        }
+
+        final String metaSkipTargetStepName = meta.getSkipTargetStep() != null ? meta.getSkipTargetStep().getName() : meta.getSkipTargetStepname();
+        if (isNotEmpty(metaSkipTargetStepName)) {
+            final RowSet rowSet = findOutputRowSet(metaSkipTargetStepName);
+            if (rowSet != null) {
+                data.setSkipOutputRowSet(rowSet);
+            } else {
+                throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindSkipTargetRowSetForStep", new Object[]{ metaSkipTargetStepName }));
+            }
+        }
+
+        final String metaTimeoutTargetStepName = meta.getTimeoutTargetStep() != null ? meta.getTimeoutTargetStep().getName() : meta.getTimeoutTargetStepname();
+        if (isNotEmpty(metaTimeoutTargetStepName)) {
+            final RowSet rowSet = findOutputRowSet(metaTimeoutTargetStepName);
+            if (rowSet != null) {
+                data.setTimeoutOutputRowSet(rowSet);
+            } else {
+                throw new KettleException(BaseMessages.getString(PKG, "CompareAndSetStep.Log.UnableToFindTimeoutTargetRowSetForStep", new Object[] { metaTimeoutTargetStepName }));
+            }
+        }
     }
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStep.java
@@ -124,7 +124,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
             } else if (ActionIfNoAtomic.Error == actionIfNoAtomic) {
                 // send row to the error output of the step
                 final String errorMessage = "CAS No Atomic object for id: " + atomicId + ", and ActionIfNoAtomic == Error";
-                this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.NO_SUCH_ATOMIC.getCode());
+                this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC.getCode());
                 logLineNumber();
                 return true; // row done!
 
@@ -136,7 +136,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                         // TIMEOUT reached!
                         // send row to the error output of the step
                         final String errorMessage = "CAS Timeout (" + waitAtomicTimeout + "ms) exceeded whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait";
-                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.NO_SUCH_ATOMIC_WAIT_TIMEOUT.getCode());
+                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC_WAIT_TIMEOUT.getCode());
                         logLineNumber();
                         return true; // row done!
                     }
@@ -144,7 +144,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                     Thread.currentThread().interrupt(); // restore interrupted flag
                     // send row to the error output of the step
                     final String errorMessage = "CAS Thread interrupted whilst waiting for Atomic object creation for id: " + atomicId + ", and ActionIfNoAtomic == Wait";
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.NO_SUCH_ATOMIC_WAIT_INTERRUPTED.getCode());
+                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.NO_SUCH_ATOMIC_WAIT_INTERRUPTED.getCode());
                     logLineNumber();
                     return true; // row done!
                 }
@@ -221,7 +221,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                 } else if (ActionIfUnableToSet.Error == actionIfUnableToSet) {
                     // send row to the error output of the step
                     final String errorMessage = "Unable to Compare And Set Value for: " + atomicId + ", and ActionIfUnableToSet == Error";
-                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.CAS_FAILED.getCode());
+                    this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.CAS_FAILED.getCode());
                     logLineNumber();
                     return true; // row done!
 
@@ -255,7 +255,7 @@ public class CompareAndSetStep extends BaseStep implements StepInterface {
                         Thread.currentThread().interrupt(); // restore interrupted flag
                         // send row to the error output of the step
                         final String errorMessage = "Thread interrupted whilst waiting to CAS Atomic value for id: " + atomicId;
-                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCodes.CAS_ATOMIC_WAIT_INTERRUPTED.getCode());
+                        this.putError(data.getOutputRowMeta(), row, 1L, errorMessage, data.getAtomicIdFieldName(), ErrorCode.CAS_ATOMIC_WAIT_INTERRUPTED.getCode());
                         logLineNumber();
                         return true; // row done!
                     }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepData.java
@@ -26,73 +26,20 @@ import org.pentaho.di.core.RowSet;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicStorage;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
-import uk.gov.nationalarchives.pdi.step.atomics.AtomicValue;
-import uk.gov.nationalarchives.pdi.step.atomics.OutputMap;
+import uk.gov.nationalarchives.pdi.step.atomics.*;
 
 import javax.annotation.Nullable;
 
 
-public class CompareAndSetStepData extends BaseStepData implements StepDataInterface {
+public class CompareAndSetStepData extends AbstractAtomicStepData {
 
-    private RowMetaInterface outputRowMeta;
-    private String atomicIdFieldName;
-    private int atomicIdFieldIndex;
-    private final OutputMap casOutputRowSets = new OutputMap();
-    private RowSet continueOutputRowSet = null;
     private RowSet skipOutputRowSet = null;
-    private RowSet timeoutOutputRowSet = null;
 
     public CompareAndSetStepData() {
         super();
     }
 
-    public @Nullable
-    AtomicValue getAtomic(final String id, final AtomicType atomicType) throws IllegalStateException {
-        return AtomicStorage.INSTANCE.getAtomic(id, atomicType);
-    }
-
-    public AtomicValue getOrCreateAtomic(final String id, final AtomicType atomicType, final String initialValue) throws IllegalStateException {
-        return AtomicStorage.INSTANCE.getOrCreateAtomic(id, atomicType, initialValue);
-    }
-
     // <editor-fold desc="get/set properties">
-    public RowMetaInterface getOutputRowMeta() {
-        return outputRowMeta;
-    }
-
-    public void setOutputRowMeta(final RowMetaInterface outputRowMeta) {
-        this.outputRowMeta = outputRowMeta;
-    }
-
-    public String getAtomicIdFieldName() {
-        return atomicIdFieldName;
-    }
-
-    public void setAtomicIdFieldName(final String atomicIdFieldName) {
-        this.atomicIdFieldName = atomicIdFieldName;
-    }
-
-    public int getAtomicIdFieldIndex() {
-        return atomicIdFieldIndex;
-    }
-
-    public void setAtomicIdFieldIndex(final int atomicIdFieldIndex) {
-        this.atomicIdFieldIndex = atomicIdFieldIndex;
-    }
-
-    public OutputMap getCasOutputRowSets() {
-        return casOutputRowSets;
-    }
-
-    public RowSet getContinueOutputRowSet() {
-        return continueOutputRowSet;
-    }
-
-    public void setContinueOutputRowSet(final RowSet continueOutputRowSet) {
-        this.continueOutputRowSet = continueOutputRowSet;
-    }
 
     public RowSet getSkipOutputRowSet() {
         return skipOutputRowSet;
@@ -100,14 +47,6 @@ public class CompareAndSetStepData extends BaseStepData implements StepDataInter
 
     public void setSkipOutputRowSet(final RowSet skipOutputRowSet) {
         this.skipOutputRowSet = skipOutputRowSet;
-    }
-
-    public RowSet getTimeoutOutputRowSet() {
-        return timeoutOutputRowSet;
-    }
-
-    public void setTimeoutOutputRowSet(final RowSet timeoutOutputRowSet) {
-        this.timeoutOutputRowSet = timeoutOutputRowSet;
     }
 
     // </editor-fold>

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepData.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepData.java
@@ -29,6 +29,7 @@ import org.pentaho.di.trans.step.StepDataInterface;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicStorage;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicValue;
+import uk.gov.nationalarchives.pdi.step.atomics.OutputMap;
 
 import javax.annotation.Nullable;
 
@@ -38,7 +39,6 @@ public class CompareAndSetStepData extends BaseStepData implements StepDataInter
     private RowMetaInterface outputRowMeta;
     private String atomicIdFieldName;
     private int atomicIdFieldIndex;
-//    private ValueMetaInterface atomicIdFieldInputValueMeta;
     private final OutputMap casOutputRowSets = new OutputMap();
     private RowSet continueOutputRowSet = null;
     private RowSet skipOutputRowSet = null;
@@ -81,14 +81,6 @@ public class CompareAndSetStepData extends BaseStepData implements StepDataInter
     public void setAtomicIdFieldIndex(final int atomicIdFieldIndex) {
         this.atomicIdFieldIndex = atomicIdFieldIndex;
     }
-
-//    public ValueMetaInterface getAtomicIdFieldInputValueMeta() {
-//        return atomicIdFieldInputValueMeta;
-//    }
-//
-//    public void setAtomicIdFieldInputValueMeta(final ValueMetaInterface atomicIdFieldInputValueMeta) {
-//        this.atomicIdFieldInputValueMeta = atomicIdFieldInputValueMeta;
-//    }
 
     public OutputMap getCasOutputRowSets() {
         return casOutputRowSets;

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepDialog.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepDialog.java
@@ -730,8 +730,8 @@ public class CompareAndSetStepDialog extends BaseStepDialog implements StepDialo
             wCompareAndSetTableView.getTable().removeAll();
             for (final CompareAndSetTarget compareAndSetValue : compareAndSetValues) {
                 // TODO(AR) fix atomic types?
-                final String targetStepname = compareAndSetValue.getTargetStep() == null ? "" : compareAndSetValue.getTargetStep().getName();
-                wCompareAndSetTableView.add(new String[]  {compareAndSetValue.getCompareValue(), compareAndSetValue.getSetValue(),  targetStepname});
+                final String targetStepname = compareAndSetValue.getTargetStep() != null ? compareAndSetValue.getTargetStep().getName() : compareAndSetValue.getTargetStepname();
+                wCompareAndSetTableView.add(new String[]  {compareAndSetValue.getCompareValue(), compareAndSetValue.getSetValue(),  emptyIfNull(targetStepname)});
             }
         }
     }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepMeta.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepMeta.java
@@ -335,10 +335,13 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
         final StepIOMetaInterface ioMeta = this.getStepIOMeta();
         final List<StreamInterface> targetStreams = ioMeta.getTargetStreams();
         for (final StreamInterface targetStream : targetStreams) {
-            final CompareAndSetTarget compareAndSetValue = (CompareAndSetTarget)targetStream.getSubject();
-            if (compareAndSetValue != null && compareAndSetValue.getTargetStep() == null) {
-                final CheckResult cr = new CheckResult(CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(PKG, "CompareAndSetStepMeta.CheckResult.TargetStepInvalid", new String[]{"false", compareAndSetValue.getTargetStepname()}), stepMeta);
-                remarks.add(cr);
+            final Object subject = targetStream.getSubject();
+            if (subject != null && subject instanceof CompareAndSetTarget) {
+                final CompareAndSetTarget compareAndSetValue = (CompareAndSetTarget) subject;
+                if (compareAndSetValue.getTargetStep() == null) {
+                    final CheckResult cr = new CheckResult(CheckResultInterface.TYPE_RESULT_ERROR, BaseMessages.getString(PKG, "CompareAndSetStepMeta.CheckResult.TargetStepInvalid", new String[]{"false", compareAndSetValue.getTargetStepname()}), stepMeta);
+                    remarks.add(cr);
+                }
             }
         }
 
@@ -418,10 +421,13 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
     public void searchInfoAndTargetSteps(final List<StepMeta> steps) {
         final List<StreamInterface> targetStreams = this.getStepIOMeta().getTargetStreams();
         for (final StreamInterface targetStream : targetStreams) {
-            final CompareAndSetTarget compareAndSetValue = (CompareAndSetTarget)targetStream.getSubject();
-            if (compareAndSetValue != null) {
+            final Object subject = targetStream.getSubject();
+            if (subject != null && subject instanceof CompareAndSetTarget) {
+                final CompareAndSetTarget compareAndSetValue = (CompareAndSetTarget) subject;
                 final StepMeta stepMeta = StepMeta.findStep(steps, compareAndSetValue.getTargetStepname());
                 compareAndSetValue.setTargetStep(stepMeta);
+            } else {
+                log.logMinimal("Unexpected Target Stream Subject Type: " + subject);
             }
         }
 
@@ -460,7 +466,12 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
             this.setTimeoutTargetStep(stream.getStepMeta());
 
         } else if (stream == NEW_CAS_TARGET_STREAM) {
-            final CompareAndSetTarget compareAndSetValue = new CompareAndSetTarget("compare1", "set1", stream.getStepMeta());
+            final CompareAndSetTarget compareAndSetValue;
+            if (atomicType == AtomicType.Integer) {
+                compareAndSetValue = new CompareAndSetTarget("12345", "54321", stream.getStepMeta());
+            } else {
+                compareAndSetValue = new CompareAndSetTarget("true", "false", stream.getStepMeta());
+            }
             if (this.compareAndSetValues == null) {
                 this.compareAndSetValues = new ArrayList<>(1);
             }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepMeta.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/atomics/compareandset/CompareAndSetStepMeta.java
@@ -45,6 +45,7 @@ import org.pentaho.di.trans.step.errorhandling.StreamInterface;
 import org.pentaho.metastore.api.IMetaStore;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
+import uk.gov.nationalarchives.pdi.step.atomics.AbstractAtomicStepMeta;
 import uk.gov.nationalarchives.pdi.step.atomics.ActionIfNoAtomic;
 import uk.gov.nationalarchives.pdi.step.atomics.ActionIfUnableToSet;
 import uk.gov.nationalarchives.pdi.step.atomics.AtomicType;
@@ -57,31 +58,16 @@ import static uk.gov.nationalarchives.pdi.step.atomics.Util.isNullOrEmpty;
 
 @Step(id = "CompareAndSetStep", image = "CompareAndSetStep.svg", name = "Compare And Set Atomic Value",
         description = "Compare and Set an Atomic Value", categoryDescription = "Flow")
-public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInterface {
+public class CompareAndSetStepMeta extends AbstractAtomicStepMeta {
 
     private static Class<?> PKG = CompareAndSetStep.class; // for i18n purposes, needed by Translator2!!   $NON-NLS-1$
 
     // <editor-fold desc="settings XML element names">
-    private static final String ELEM_NAME_ATOMIC_ID_FIELD_NAME = "atomicIdFieldName";
-    private static final String ELEM_NAME_ATOMIC_TYPE = "atomicType";
-    private static final String ELEM_NAME_ACTION_IF_NO_ATOMIC = "actionIfNoAtomic";
-    private static final String ATTR_NAME_CONTINUE_TARGET_STEP = "continueTargetStep";
-    private static final String ATTR_NAME_CHECK_PERIOD = "checkPeriod";
-    private static final String ATTR_NAME_TIMEOUT = "timeout";
-    private static final String ATTR_NAME_VALUE = "value";
     private static final String ELEM_NAME_ACTION_IF_UNABLE_TO_SET = "actionIfUnableToSet";
     private static final String ATTR_NAME_SKIP_TARGET_STEP = "skipTargetStep";
-    private static final String ATTR_NAME_TIMEOUT_TARGET_STEP = "timeoutTargetStep";
-    private static final String ELEM_NAME_ATOMIC_VALUES = "atomicValues";
-    private static final String ELEM_NAME_ATOMIC_VALUE = "atomicValue";
     private static final String ATTR_NAME_COMPARE = "compare";
     private static final String ATTR_NAME_SET = "set";
-    private static final String ATTR_NAME_TARGET_STEP = "targetStep";
     // </editor-fold>
-
-    private static final long DEFAULT_CHECK_PERIOD = 100; // ms
-    private static final long TIMEOUT_DISABLED = -1; // No timeout
-    private static final long DEFAULT_TIMEOUT = TIMEOUT_DISABLED;
 
     private static final Stream NEW_CONTINUE_STREAM = new Stream(StreamInterface.StreamType.TARGET, (StepMeta)null, BaseMessages.getString(PKG, "CompareAndSetStepMeta.TargetStream.Continue.Description", new String[0]), StreamIcon.TARGET, (Object)null);
     private static final Stream NEW_SKIP_STREAM = new Stream(StreamInterface.StreamType.TARGET, (StepMeta)null, BaseMessages.getString(PKG, "CompareAndSetStepMeta.TargetStream.Skip.Description", new String[0]), StreamIcon.TARGET, (Object)null);
@@ -89,33 +75,18 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
     private static final Stream NEW_CAS_TARGET_STREAM = new Stream(StreamInterface.StreamType.TARGET, (StepMeta)null, BaseMessages.getString(PKG, "CompareAndSetStepMeta.TargetStream.NewCASTarget.Description", new String[0]), StreamIcon.TARGET, (Object)null);
 
     // <editor-fold desc="settings">
-    private String atomicIdFieldName;
-    private AtomicType atomicType;
-    private ActionIfNoAtomic actionIfNoAtomic;
-    private String continueTargetStepname;
-    @Nullable private String initialiseAtomicValue;
-    private long waitAtomicCheckPeriod = DEFAULT_CHECK_PERIOD;
-    private long waitAtomicTimeout = DEFAULT_TIMEOUT;
     private ActionIfUnableToSet actionIfUnableToSet;
     private String skipTargetStepname;
     private long unableToSetLoopCheckPeriod = DEFAULT_CHECK_PERIOD;
     private long unableToSetLoopTimeout = DEFAULT_TIMEOUT;
-    private String timeoutTargetStepname;
     @Nullable private List<CompareAndSetTarget> compareAndSetValues;
     // </editor-fold>
 
-    @Nullable private StepMeta continueTargetStep;
     @Nullable private StepMeta skipTargetStep;
-    @Nullable private StepMeta timeoutTargetStep;
 
     @Override
     public void setDefault() {
-        atomicIdFieldName = "";
-        atomicType = AtomicType.Boolean;
-        actionIfNoAtomic = ActionIfNoAtomic.Continue;
-        initialiseAtomicValue = null;
-        waitAtomicCheckPeriod = DEFAULT_CHECK_PERIOD;
-        waitAtomicTimeout = DEFAULT_TIMEOUT;
+        super.setDefault();
         actionIfUnableToSet = ActionIfUnableToSet.Error;
         unableToSetLoopCheckPeriod = DEFAULT_CHECK_PERIOD;
         unableToSetLoopTimeout = DEFAULT_TIMEOUT;
@@ -498,70 +469,6 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
     }
 
     // <editor-fold desc="settings getters and setters">
-    public String getAtomicIdFieldName() {
-        return atomicIdFieldName;
-    }
-
-    public void setAtomicIdFieldName(final String atomicIdFieldName) {
-        this.atomicIdFieldName = atomicIdFieldName;
-    }
-
-    public AtomicType getAtomicType() {
-        return atomicType;
-    }
-
-    public void setAtomicType(final AtomicType atomicType) {
-        this.atomicType = atomicType;
-    }
-
-    public ActionIfNoAtomic getActionIfNoAtomic() {
-        return actionIfNoAtomic;
-    }
-
-    public void setActionIfNoAtomic(final ActionIfNoAtomic actionIfNoAtomic) {
-        this.actionIfNoAtomic = actionIfNoAtomic;
-    }
-
-    public String getContinueTargetStepname() {
-        return continueTargetStepname;
-    }
-
-    public void setContinueTargetStepname(final String continueTargetStepname) {
-        this.continueTargetStepname = continueTargetStepname;
-    }
-
-    @Nullable public StepMeta getContinueTargetStep() {
-        return continueTargetStep;
-    }
-
-    public void setContinueTargetStep(@Nullable final StepMeta continueTargetStep) {
-        this.continueTargetStep = continueTargetStep;
-    }
-
-    public @Nullable String getInitialiseAtomicValue() {
-        return initialiseAtomicValue;
-    }
-
-    public void setInitialiseAtomicValue(@Nullable final String initialiseAtomicValue) {
-        this.initialiseAtomicValue = initialiseAtomicValue;
-    }
-
-    public long getWaitAtomicCheckPeriod() {
-        return waitAtomicCheckPeriod;
-    }
-
-    public void setWaitAtomicCheckPeriod(final long waitAtomicCheckPeriod) {
-        this.waitAtomicCheckPeriod = waitAtomicCheckPeriod;
-    }
-
-    public long getWaitAtomicTimeout() {
-        return waitAtomicTimeout;
-    }
-
-    public void setWaitAtomicTimeout(final long waitAtomicTimeout) {
-        this.waitAtomicTimeout = waitAtomicTimeout;
-    }
-
     public ActionIfUnableToSet getActionIfUnableToSet() {
         return actionIfUnableToSet;
     }
@@ -602,22 +509,6 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
         this.unableToSetLoopTimeout = unableToSetLoopTimeout;
     }
 
-    public String getTimeoutTargetStepname() {
-        return timeoutTargetStepname;
-    }
-
-    public void setTimeoutTargetStepname(final String timeoutTargetStepname) {
-        this.timeoutTargetStepname = timeoutTargetStepname;
-    }
-
-    public StepMeta getTimeoutTargetStep() {
-        return timeoutTargetStep;
-    }
-
-    public void setTimeoutTargetStep(final StepMeta timeoutTargetStep) {
-        this.timeoutTargetStep = timeoutTargetStep;
-    }
-
     public @Nullable List<CompareAndSetTarget> getCompareAndSetValues() {
         return compareAndSetValues;
     }
@@ -625,6 +516,5 @@ public class CompareAndSetStepMeta extends BaseStepMeta implements StepMetaInter
     public void setCompareAndSetValues(@Nullable final List<CompareAndSetTarget> compareAndSetValues) {
         this.compareAndSetValues = compareAndSetValues;
     }
-
     // </editor-fold>
 }

--- a/src/main/resources/uk/gov/nationalarchives/pdi/step/atomics/await/messages/messages_en_US.properties
+++ b/src/main/resources/uk/gov/nationalarchives/pdi/step/atomics/await/messages/messages_en_US.properties
@@ -28,9 +28,9 @@ AwaitStepDialog.TextFieldAtomicId=Atomic ID Field Name\:
 AwaitStepDialog.IfNoSuchAtomic=If no such Atomic?\:
 AwaitStepDialog.TextFieldContinueTarget=Continue target step\:
 AwaitStepDialog.ComboAtomicType=Atomic Type\:
-AwaitStepDialog.TextFieldAtomicValue=Atomic Value\:
-AwaitStepDialog.TextFieldAtomicValueTarget=Target step\:
-AwaitStepDialog.CheckboxDiscardAtomic=Discard Atomic?\:
+AwaitStepDialog.AtomicValue=Atomic Value
+AwaitStepDialog.TargetStep=Target step
+AwaitStepDialog.DiscardAtomic=Discard Atomic?
 AwaitStepDialog.GroupText.WaitLoop=Wait Loop
 AwaitStepDialog.TextFieldCheckPeriod=Check Period (ms)\:
 AwaitStepDialog.TextFieldTimeout=Timeout (ms)\:
@@ -39,10 +39,11 @@ AwaitStepDialog.TextFieldTimeoutTarget=Timeout target step\:
 AwaitStep.Log.LineNumber=Linenr 
 AwaitStep.Log.NoContinueTargetStep=Continue on no such Atomic, but no Continue target step specified
 AwaitStep.Log.UnableToFindContinueTargetRowSetForStep=Unable to find row set for Continue target step
-AwaitStep.Log.NoAtomicValueTargetStep=No Atomic Value target step specified
+AwaitStep.Log.NoTargetStepSpecifiedForValue=There was no target step (or an unknown target step) specified for Await {0}.
 AwaitStep.Log.UnableToFindAtomicValueTargetRowSetForStep=Unable to find row set for Atomic Value target step
 AwaitStep.Log.NoTimeoutTargetStep=Timeout on wait, but no Timeout target step specified
 AwaitStep.Log.UnableToFindTimeoutTargetRowSetForStep=Unable to find row set for Timeout target step
+AwaitStep.Log.UnableToFindTargetRowSetForStep=Unable to find target step {0}
 
 AwaitStepMeta.TargetStream.Timeout.Description=Timeout output of step
 

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/UtilTest.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/UtilTest.java
@@ -45,6 +45,26 @@ public class UtilTest {
     }
 
     @Test
+    public void strNullIfNull() {
+        assertEquals("null", Util.strNullIfNull(null));
+        assertEquals("", Util.strNullIfNull(""));
+        assertEquals("a", Util.strNullIfNull("a"));
+        assertEquals("abc", Util.strNullIfNull("abc"));
+        assertEquals("null", Util.strNullIfNull("null"));
+        assertEquals("nullify", Util.strNullIfNull("nullify"));
+    }
+
+    @Test
+    public void nullIfStrNull() {
+        assertNull(Util.nullIfStrNull(null));
+        assertEquals("", Util.nullIfStrNull(""));
+        assertEquals("a", Util.nullIfStrNull("a"));
+        assertEquals("abc", Util.nullIfStrNull("abc"));
+        assertNull(Util.nullIfStrNull("null"));
+        assertEquals("nullify", Util.nullIfStrNull("nullify"));
+    }
+
+    @Test
     public void isNullOrEmptyString() {
         assertTrue(Util.isNullOrEmpty(null));
         assertTrue(Util.isNullOrEmpty(""));

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitIT.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/atomics/await/AwaitIT.java
@@ -78,8 +78,7 @@ public class AwaitIT {
         awaitStepMeta.setActionIfNoAtomic(ActionIfNoAtomic.Initialise);
         awaitStepMeta.setAtomicType(atomicType);
         awaitStepMeta.setInitialiseAtomicValue(initialiseValue);
-        awaitStepMeta.setAtomicValue(initialiseValue);
-        awaitStepMeta.setAtomicValueTargetStepname(TransTestFactory.DUMMY_STEPNAME);
+        awaitStepMeta.setAwaitValues(Arrays.asList(new AwaitTarget(initialiseValue, false, TransTestFactory.DUMMY_STEPNAME)));
 
         final TransMeta transMeta = TransTestFactory.generateTestTransformation(new Variables(), awaitStepMeta, stepName);
         final List<RowMetaAndData> result = TransTestFactory.executeTestTransformation(
@@ -131,8 +130,7 @@ public class AwaitIT {
         awaitStepMeta.setActionIfNoAtomic(ActionIfNoAtomic.Initialise);
         awaitStepMeta.setAtomicType(atomicType);
         awaitStepMeta.setInitialiseAtomicValue(initialiseValue);
-        awaitStepMeta.setAtomicValue(existingAtomicValue);
-        awaitStepMeta.setAtomicValueTargetStepname(TransTestFactory.DUMMY_STEPNAME);
+        awaitStepMeta.setAwaitValues(Arrays.asList(new AwaitTarget(existingAtomicValue, false, TransTestFactory.DUMMY_STEPNAME)));
 
         final TransMeta transMeta = TransTestFactory.generateTestTransformation(new Variables(), awaitStepMeta, stepName);
         final List<RowMetaAndData> result = TransTestFactory.executeTestTransformation(
@@ -243,8 +241,7 @@ public class AwaitIT {
         awaitStepMeta.setActionIfNoAtomic(ActionIfNoAtomic.Wait);
         awaitStepMeta.setWaitAtomicTimeout(5000);  // a suitably long time to enable us to set it
         awaitStepMeta.setWaitAtomicCheckPeriod(50);
-        awaitStepMeta.setAtomicValue(waitForValue);
-        awaitStepMeta.setAtomicValueTargetStepname(TransTestFactory.DUMMY_STEPNAME);
+        awaitStepMeta.setAwaitValues(Arrays.asList(new AwaitTarget(waitForValue, false, TransTestFactory.DUMMY_STEPNAME)));
 
         final AtomicValue atomicValue;
         if (atomicType == AtomicType.Integer) {
@@ -367,8 +364,7 @@ public class AwaitIT {
         awaitStepMeta.setAtomicType(atomicType);
         awaitStepMeta.setWaitLoopTimeout(5000);  // a suitably long time to enable us to set it
         awaitStepMeta.setWaitLoopCheckPeriod(50);
-        awaitStepMeta.setAtomicValue(updatedAtomicValue);
-        awaitStepMeta.setAtomicValueTargetStepname(TransTestFactory.DUMMY_STEPNAME);
+        awaitStepMeta.setAwaitValues(Arrays.asList(new AwaitTarget(updatedAtomicValue, false, TransTestFactory.DUMMY_STEPNAME)));
 
         final AtomicValue atomicValue2;
         if (atomicType == AtomicType.Integer) {
@@ -448,7 +444,7 @@ public class AwaitIT {
         awaitStepMeta.setAtomicType(atomicType);
         awaitStepMeta.setWaitLoopTimeout(200);
         awaitStepMeta.setWaitAtomicCheckPeriod(50);
-        awaitStepMeta.setAtomicValue(awaitAtomicValue);
+        awaitStepMeta.setAwaitValues(Arrays.asList(new AwaitTarget(awaitAtomicValue, false, AwaitStep.IGNORE_STEPNAME_FOR_TEST)));
 //        awaitStepMeta.setAtomicValueTargetStepname(TransTestFactory.DUMMY_STEPNAME);
         awaitStepMeta.setTimeoutTargetStepname(TransTestFactory.DUMMY_STEPNAME);
 


### PR DESCRIPTION
Previously the AwaitStep could only wait for a single value to be set. This enhancement adds two features:

1. The AwaitStep can now wait on one of several values to be set. Each value can have its own target step. 
2. The AwaitStep can wait for the value to become null, this can also have its own target step. This is useful when waiting for completion of a process by flag, or removal of the flag due to cleanup (after process completion).

Being able to wait for either a completion value or null, enables us to safely handle possible race-conditions when discarding the AtomicValue in other steps.